### PR TITLE
feat(phase1): core partition infrastructure (epoch, _ensure_partition, _partition_inventory, GC)

### DIFF
--- a/_record/install.sql
+++ b/_record/install.sql
@@ -4753,15 +4753,15 @@ COMMENT ON FUNCTION pgfr_record.config_recommendations() IS
 --    seconds offset from this point. Changing it corrupts all timestamps.
 --    See §7.1 and Q6 in SPEC.md.
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record.epoch()
-RETURNS timestamptz
-IMMUTABLE
-LANGUAGE sql
-AS $$
-    SELECT '2026-01-01 00:00:00+00'::timestamptz;
+create or replace function pgfr_record.epoch()
+returns timestamptz
+immutable
+language sql
+as $$
+    select '2026-01-01 00:00:00+00'::timestamptz;
 $$;
 
-COMMENT ON FUNCTION pgfr_record.epoch() IS
+comment on function pgfr_record.epoch() is
 'Fixed installation epoch (2026-01-01 UTC) for int4 sample_ts offsets. '
 'NEVER change this after installation — all stored timestamps are seconds '
 'relative to this point. Overflow horizon: ~2094. '
@@ -4773,35 +4773,43 @@ COMMENT ON FUNCTION pgfr_record.epoch() IS
 --    O(1) happy path: returns immediately if partition already exists.
 --    Creates partition with UTC-enforced bounds + B-tree + BRIN indexes.
 --    Safe to call from snapshot() on every tick as a runtime safety net.
+--
+--    WARNING: p_table must have columns (queryid, dbid, userid, toplevel, sample_ts)
+--    — the B-tree index is hardcoded to these columns. Calls for tables without
+--    these columns will fail with 'column does not exist'.
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record._ensure_partition(
+create or replace function pgfr_record._ensure_partition(
     p_table text,
     p_date  date
 )
-RETURNS void
-LANGUAGE plpgsql
-AS $$
-DECLARE
+returns void
+language plpgsql
+as $$
+declare
     v_partition_name text;
     v_bound_start    int4;
     v_bound_end      int4;
     v_date_start_ts  timestamptz;
     v_date_end_ts    timestamptz;
-BEGIN
+begin
+    -- Column contract: p_table must have (queryid, dbid, userid, toplevel, sample_ts).
+    -- The B-tree index below is hardcoded to these columns; missing columns cause
+    -- 'column does not exist' errors. Verify your table schema before calling.
+
     -- Derive partition name from date (YYYY_MM_DD suffix)
     v_partition_name := p_table || '_' || to_char(p_date, 'YYYY_MM_DD');
 
     -- O(1) happy path: check pg_class, return immediately if partition exists.
     -- No DDL, no lock acquisition on the common code path.
-    IF EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = v_partition_name
-    ) THEN
-        RETURN;
-    END IF;
+    if exists (
+        select 1
+        from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = v_partition_name
+    ) then
+        return;
+    end if;
 
     -- Compute UTC-enforced int4 bounds.
     -- Always use explicit +00 to prevent session timezone drift (pg_cron risk).
@@ -4813,10 +4821,10 @@ BEGIN
     v_bound_end   := extract(epoch from (v_date_end_ts   - pgfr_record.epoch()))::int4;
 
     -- Create the partition
-    EXECUTE format(
-        'CREATE TABLE IF NOT EXISTS pgfr_record.%I
-         PARTITION OF pgfr_record.%I
-         FOR VALUES FROM (%s) TO (%s)',
+    execute format(
+        'create table if not exists pgfr_record.%I
+         partition of pgfr_record.%I
+         for values from (%s) to (%s)',
         v_partition_name,
         p_table,
         v_bound_start,
@@ -4825,9 +4833,10 @@ BEGIN
 
     -- B-tree index: supports point-in-time reconstruction and sparse insert lookback.
     -- Access pattern: filter on (queryid, dbid, userid, toplevel), order by sample_ts DESC.
-    EXECUTE format(
-        'CREATE INDEX IF NOT EXISTS %I
-         ON pgfr_record.%I (queryid, dbid, userid, toplevel, sample_ts DESC)',
+    -- Requires columns: queryid, dbid, userid, toplevel, sample_ts (see column contract above).
+    execute format(
+        'create index if not exists %I
+         on pgfr_record.%I (queryid, dbid, userid, toplevel, sample_ts desc)',
         v_partition_name || '_btree_idx',
         v_partition_name
     );
@@ -4835,24 +4844,27 @@ BEGIN
     -- BRIN index: for pure time-range aggregate queries ("last hour").
     -- pages_per_range=8 chosen for sparse workloads (50-200 rows/tick).
     -- Within-day insert order guarantees high correlation for BRIN effectiveness.
-    EXECUTE format(
-        'CREATE INDEX IF NOT EXISTS %I
-         ON pgfr_record.%I
-         USING brin (sample_ts) WITH (pages_per_range = 8)',
+    execute format(
+        'create index if not exists %I
+         on pgfr_record.%I
+         using brin (sample_ts) with (pages_per_range = 8)',
         v_partition_name || '_brin_idx',
         v_partition_name
     );
 
-END;
+end;
 $$;
 
-COMMENT ON FUNCTION pgfr_record._ensure_partition(text, date) IS
+comment on function pgfr_record._ensure_partition(text, date) is
 'Idempotent daily partition creator for pgfr_record partitioned tables. '
 'O(1) happy path via pg_class existence check — returns immediately if partition exists. '
 'UTC-enforced bounds prevent session timezone drift. '
 'Creates B-tree index (queryid, dbid, userid, toplevel, sample_ts DESC) for point-in-time reads '
 'and BRIN index (sample_ts, pages_per_range=8) for time-range aggregates. '
-'Safe to call from snapshot() on every tick. See blueprints/SPEC.md §7.2.';
+'Safe to call from snapshot() on every tick. See blueprints/SPEC.md §7.2. '
+'WARNING: p_table must have columns (queryid, dbid, userid, toplevel, sample_ts) — '
+'the B-tree index is hardcoded to these columns. Calls for tables without these columns '
+'will fail with ''column does not exist''.';
 
 -- -----------------------------------------------------------------------------
 -- 3. pgfr_record._partition_inventory()
@@ -4868,12 +4880,13 @@ COMMENT ON FUNCTION pgfr_record._ensure_partition(text, date) IS
 --    is_empty: uses pg_relation_size(oid) = 0 ONLY.
 --              Never reltuples — lags until next ANALYZE, unreliable post-TRUNCATE.
 --
---    Bound parsing: defensive regex on pg_get_expr() output.
+--    Bound parsing: defensive regex on pg_get_expr() output via LATERAL join.
 --                   pg_get_expr format is not guaranteed stable across PG versions.
 --                   Fails loudly on unexpected format (strict assertion).
+--                   LATERAL join evaluates regexp_match once per row (not 5×).
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record._partition_inventory()
-RETURNS TABLE (
+create or replace function pgfr_record._partition_inventory()
+returns table (
     parent_table   text,
     partition_name text,
     bound_start    int4,
@@ -4882,10 +4895,10 @@ RETURNS TABLE (
     is_ancient     boolean,
     is_empty       boolean
 )
-LANGUAGE plpgsql
-STABLE
-AS $$
-DECLARE
+language plpgsql
+stable
+as $$
+declare
     v_partstrat      char;
     v_partnatts      int2;
     v_atttypid       oid;
@@ -4895,65 +4908,65 @@ DECLARE
     v_ancient_cutoff int4;
     v_parent_oid     oid;
     v_parent_name    text;
-BEGIN
+begin
     -- -------------------------------------------------------------------------
     -- Runtime assertions: verify all pgfr_record partitioned tables conform.
     -- We assert once per parent, fail loudly on first violation.
     -- -------------------------------------------------------------------------
-    FOR v_parent_oid, v_parent_name IN
-        SELECT pt.partrelid, pc.relname
-        FROM pg_catalog.pg_partitioned_table pt
-        JOIN pg_catalog.pg_class pc ON pc.oid = pt.partrelid
-        JOIN pg_catalog.pg_namespace pn ON pn.oid = pc.relnamespace
-        WHERE pn.nspname = 'pgfr_record'
-    LOOP
-        SELECT pt.partstrat, pt.partnatts
-          INTO v_partstrat, v_partnatts
-        FROM pg_catalog.pg_partitioned_table pt
-        WHERE pt.partrelid = v_parent_oid;
+    for v_parent_oid, v_parent_name in
+        select pt.partrelid, pc.relname
+        from pg_catalog.pg_partitioned_table pt
+        join pg_catalog.pg_class pc on pc.oid = pt.partrelid
+        join pg_catalog.pg_namespace pn on pn.oid = pc.relnamespace
+        where pn.nspname = 'pgfr_record'
+    loop
+        select pt.partstrat, pt.partnatts
+          into v_partstrat, v_partnatts
+        from pg_catalog.pg_partitioned_table pt
+        where pt.partrelid = v_parent_oid;
 
         -- Assert RANGE partitioning
-        IF v_partstrat <> 'r' THEN
-            RAISE EXCEPTION
+        if v_partstrat <> 'r' then
+            raise exception
                 '_partition_inventory(): table pgfr_record.% uses partitioning strategy "%" — '
                 'only RANGE (r) is supported. Fix the table or exclude it from pgfr_record schema.',
                 v_parent_name, v_partstrat;
-        END IF;
+        end if;
 
         -- Assert single partition key column
-        IF v_partnatts <> 1 THEN
-            RAISE EXCEPTION
+        if v_partnatts <> 1 then
+            raise exception
                 '_partition_inventory(): table pgfr_record.% has % partition key columns — '
                 'only single-column RANGE partitioning on int4 is supported.',
                 v_parent_name, v_partnatts;
-        END IF;
+        end if;
 
         -- Assert int4 (oid=23) partition key type
-        SELECT pa.atttypid INTO v_atttypid
-        FROM pg_catalog.pg_partitioned_table pt
-        JOIN pg_catalog.pg_attribute pa
-          ON pa.attrelid = pt.partrelid
-         AND pa.attnum   = pt.partattrs[0]
-        WHERE pt.partrelid = v_parent_oid;
+        select pa.atttypid into v_atttypid
+        from pg_catalog.pg_partitioned_table pt
+        join pg_catalog.pg_attribute pa
+          on pa.attrelid = pt.partrelid
+         and pa.attnum   = pt.partattrs[0]
+        where pt.partrelid = v_parent_oid;
 
-        IF v_atttypid <> 23 THEN  -- 23 = int4
-            RAISE EXCEPTION
+        if v_atttypid <> 23 then  -- 23 = int4
+            raise exception
                 '_partition_inventory(): table pgfr_record.% partition key type OID is % — '
                 'expected int4 (OID 23). Only int4 partition keys are supported.',
                 v_parent_name, v_atttypid;
-        END IF;
-    END LOOP;
+        end if;
+    end loop;
 
     -- -------------------------------------------------------------------------
     -- Compute retention cutoffs
     -- -------------------------------------------------------------------------
-    v_retention_days := COALESCE(
+    v_retention_days := coalesce(
         pgfr_record._get_config('retention_snapshots_days', '30')::int,
         30
     );
 
     -- Cutoff for is_expired: upper bound < now - retention_days (UTC)
-    v_cutoff_ts := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+    v_cutoff_ts := date_trunc('day', now() at time zone 'UTC') at time zone 'UTC'
                    - (v_retention_days || ' days')::interval;
     v_cutoff    := extract(epoch from (v_cutoff_ts - pgfr_record.epoch()))::int4;
 
@@ -4963,83 +4976,58 @@ BEGIN
     )::int4;
 
     -- -------------------------------------------------------------------------
-    -- Main catalog query with defensive bound parsing
+    -- Main catalog query with defensive bound parsing via LATERAL join.
+    -- regexp_match is called once per row (not 5×) — evaluated in the LATERAL
+    -- subquery and referenced by column alias in the SELECT list.
     -- -------------------------------------------------------------------------
-    RETURN QUERY
-    SELECT
-        parent.relname::text                            AS parent_table,
-        child.relname::text                             AS partition_name,
-        -- Parse lower int4 bound from pg_get_expr output.
+    return query
+    select
+        parent.relname::text                              as parent_table,
+        child.relname::text                               as partition_name,
+        -- Lower int4 bound from LATERAL-parsed regex result.
         -- Expected format: "FOR VALUES FROM (NNN) TO (MMM)"
-        -- Defensive regex: extract first integer literal from expression.
-        -- Raises exception if format is unexpected (strict).
-        (
-            SELECT (regexp_match(
-                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
-                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
-            ))[1]::int4
-        )                                               AS bound_start,
-        -- Parse upper int4 bound (second capture group)
-        (
-            SELECT (regexp_match(
-                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
-                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
-            ))[2]::int4
-        )                                               AS bound_end,
+        parsed.bounds[1]::int4                            as bound_start,
+        -- Upper int4 bound (second capture group)
+        parsed.bounds[2]::int4                            as bound_end,
         -- is_expired: partition upper bound falls before retention cutoff
-        (
-            (regexp_match(
-                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
-                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
-            ))[2]::int4 < v_cutoff
-        )                                               AS is_expired,
+        (parsed.bounds[2]::int4 < v_cutoff)              as is_expired,
         -- is_ancient: partition upper bound falls before 2× retention cutoff
-        (
-            (regexp_match(
-                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
-                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
-            ))[2]::int4 < v_ancient_cutoff
-        )                                               AS is_ancient,
+        (parsed.bounds[2]::int4 < v_ancient_cutoff)      as is_ancient,
         -- is_empty: authoritative — pg_relation_size = 0.
         -- Never reltuples: lags until ANALYZE, unreliable post-TRUNCATE.
-        (pg_catalog.pg_relation_size(child.oid) = 0)   AS is_empty
-    FROM pg_catalog.pg_inherits i
-    JOIN pg_catalog.pg_class child   ON child.oid  = i.inhrelid
-    JOIN pg_catalog.pg_class parent  ON parent.oid = i.inhparent
-    JOIN pg_catalog.pg_namespace n   ON n.oid      = child.relnamespace
-    WHERE n.nspname = 'pgfr_record'
+        (pg_catalog.pg_relation_size(child.oid) = 0)     as is_empty
+    from pg_catalog.pg_inherits i
+    join pg_catalog.pg_class child   on child.oid  = i.inhrelid
+    join pg_catalog.pg_class parent  on parent.oid = i.inhparent
+    join pg_catalog.pg_namespace n   on n.oid      = child.relnamespace
+    -- LATERAL: evaluate regexp_match once per row; result reused for all 5 references above.
+    -- Defensive regex on pg_get_expr() output — pg_get_expr format not guaranteed stable.
+    cross join lateral (
+        select regexp_match(
+            pg_catalog.pg_get_expr(child.relpartbound, child.oid),
+            E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
+        ) as bounds
+    ) as parsed
+    where n.nspname = 'pgfr_record'
       -- Only RANGE partitions (skip non-partition children if any)
-      AND child.relkind = 'r'
-      -- Verify the bound expression matches expected int4 RANGE format;
-      -- raise a clear error if it doesn't (defensive assertion).
-      AND (
-          CASE
-              WHEN (regexp_match(
-                      pg_catalog.pg_get_expr(child.relpartbound, child.oid),
-                      E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
-                   )) IS NULL
-              THEN (
-                  -- Raise from within a CASE requires a trick: cast NULL to fail type
-                  -- Instead we filter these out and raise above via assertion loop.
-                  -- Any child that doesn't match the regex is excluded here,
-                  -- causing the assertion loop to catch schema violations on parent.
-                  false
-              )
-              ELSE true
-          END
-      )
-    ORDER BY parent.relname, child.relname;
+      and child.relkind = 'r'
+      -- Exclude children with unparseable bounds (assertion loop above catches parent violations).
+      -- Any child that doesn't match the regex is excluded here; schema violations on
+      -- the parent are caught by the assertion loop above.
+      and parsed.bounds is not null
+    order by parent.relname, child.relname;
 
     -- Post-query check: if any child had unparseable bounds, the assertion loop
     -- above would have already raised. Unparseable children are filtered above.
     -- This is belt-and-suspenders: loudly fail on schema violations.
-END;
+end;
 $$;
 
-COMMENT ON FUNCTION pgfr_record._partition_inventory() IS
+comment on function pgfr_record._partition_inventory() is
 'Catalog-based partition introspection for pgfr_record schema. '
 'Runtime assertions: verifies RANGE partitioning, single column, int4 key type — raises exception on violation. '
 'is_empty uses pg_relation_size(oid)=0 ONLY (authoritative after TRUNCATE; never reltuples which lags). '
+'LATERAL join evaluates regexp_match once per row (not 5×) for bound parsing efficiency. '
 'Defensive regex parsing of pg_get_expr() output — fails loudly on unexpected format. '
 'Assumes single-column RANGE partitioning on int4 throughout. '
 'Used by truncate_old_partitions(), drop_ancient_partitions(), and partition_gc_health view. '
@@ -5052,51 +5040,51 @@ COMMENT ON FUNCTION pgfr_record._partition_inventory() IS
 --    Loops ALL eligible partitions; skips locked ones (continues to next).
 --    Storage reclaimed immediately. Partition definition remains for planner pruning.
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record.truncate_old_partitions()
-RETURNS void
-LANGUAGE plpgsql
-AS $$
-DECLARE
+create or replace function pgfr_record.truncate_old_partitions()
+returns void
+language plpgsql
+as $$
+declare
     v_rec             record;
     v_truncated_count int := 0;
     v_skipped_count   int := 0;
-BEGIN
-    FOR v_rec IN
-        SELECT parent_table, partition_name
-        FROM pgfr_record._partition_inventory()
-        WHERE is_expired AND NOT is_empty
-        ORDER BY parent_table, partition_name
-    LOOP
-        BEGIN
+begin
+    for v_rec in
+        select parent_table, partition_name
+        from pgfr_record._partition_inventory()
+        where is_expired and not is_empty
+        order by parent_table, partition_name
+    loop
+        begin
             -- 50ms timeout: FIFO queue means waiting longer stalls all readers.
             -- If we miss this window, we retry next hour — lag is not permanent.
-            SET LOCAL lock_timeout = '50ms';
-            EXECUTE format('TRUNCATE pgfr_record.%I', v_rec.partition_name);
+            set local lock_timeout = '50ms';
+            execute format('truncate pgfr_record.%I', v_rec.partition_name);
             v_truncated_count := v_truncated_count + 1;
-            RAISE NOTICE 'pgfr_record: Truncated expired partition pgfr_record.%', v_rec.partition_name;
-        EXCEPTION
-            WHEN lock_not_available THEN
+            raise notice 'pgfr_record: Truncated expired partition pgfr_record.%', v_rec.partition_name;
+        exception
+            when lock_not_available then
                 -- Skip this partition and continue to next — do NOT abort.
                 -- Best-effort retention: never stall the collection loop.
                 v_skipped_count := v_skipped_count + 1;
-                RAISE NOTICE 'pgfr_record: Skipped pgfr_record.% (lock_timeout exceeded, will retry next run)',
+                raise notice 'pgfr_record: Skipped pgfr_record.% (lock_timeout exceeded, will retry next run)',
                     v_rec.partition_name;
-            WHEN OTHERS THEN
+            when others then
                 -- Unexpected error: log and continue to next partition.
                 v_skipped_count := v_skipped_count + 1;
-                RAISE WARNING 'pgfr_record: Failed to truncate pgfr_record.%: %',
-                    v_rec.partition_name, SQLERRM;
-        END;
-    END LOOP;
+                raise warning 'pgfr_record: Failed to truncate pgfr_record.%: %',
+                    v_rec.partition_name, sqlerrm;
+        end;
+    end loop;
 
-    IF v_truncated_count > 0 OR v_skipped_count > 0 THEN
-        RAISE NOTICE 'pgfr_record: truncate_old_partitions() complete: % truncated, % skipped',
+    if v_truncated_count > 0 or v_skipped_count > 0 then
+        raise notice 'pgfr_record: truncate_old_partitions() complete: % truncated, % skipped',
             v_truncated_count, v_skipped_count;
-    END IF;
-END;
+    end if;
+end;
 $$;
 
-COMMENT ON FUNCTION pgfr_record.truncate_old_partitions() IS
+comment on function pgfr_record.truncate_old_partitions() is
 'Nightly GC: TRUNCATE expired (is_expired AND NOT is_empty) partitions from _partition_inventory(). '
 'lock_timeout=50ms — aggressive to avoid FIFO queue stalls on ACCESS EXCLUSIVE. '
 'Loops ALL eligible partitions; skips locked ones (continues, does not abort). '
@@ -5111,53 +5099,53 @@ COMMENT ON FUNCTION pgfr_record.truncate_old_partitions() IS
 --    lock_timeout = 2s (plain DROP TABLE, no DETACH needed — table is empty).
 --    Keeps total partition count permanently bounded.
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record.drop_ancient_partitions()
-RETURNS void
-LANGUAGE plpgsql
-AS $$
-DECLARE
+create or replace function pgfr_record.drop_ancient_partitions()
+returns void
+language plpgsql
+as $$
+declare
     v_rec           record;
     v_dropped_count int := 0;
     v_skipped_count int := 0;
-BEGIN
+begin
     -- Target: is_ancient (>2× retention window) AND is_empty (already truncated).
     -- Empty partitions have no concurrent readers — plain DROP TABLE suffices.
     -- No DETACH CONCURRENTLY needed: empty table, no live data, no user sessions touching it.
-    FOR v_rec IN
-        SELECT parent_table, partition_name
-        FROM pgfr_record._partition_inventory()
-        WHERE is_ancient AND is_empty
-        ORDER BY parent_table, partition_name
-    LOOP
-        BEGIN
+    for v_rec in
+        select parent_table, partition_name
+        from pgfr_record._partition_inventory()
+        where is_ancient and is_empty
+        order by parent_table, partition_name
+    loop
+        begin
             -- 2s timeout: empty partition DROP is fast (catalog change only).
             -- Longer than truncate_old_partitions (50ms) because this is monthly
             -- and the table is empty — contention is unlikely, worth waiting briefly.
-            SET LOCAL lock_timeout = '2s';
-            EXECUTE format('DROP TABLE IF EXISTS pgfr_record.%I', v_rec.partition_name);
+            set local lock_timeout = '2s';
+            execute format('drop table if exists pgfr_record.%I', v_rec.partition_name);
             v_dropped_count := v_dropped_count + 1;
-            RAISE NOTICE 'pgfr_record: Dropped ancient empty partition pgfr_record.%', v_rec.partition_name;
-        EXCEPTION
-            WHEN lock_not_available THEN
+            raise notice 'pgfr_record: Dropped ancient empty partition pgfr_record.%', v_rec.partition_name;
+        exception
+            when lock_not_available then
                 -- Skip and try next monthly run.
                 v_skipped_count := v_skipped_count + 1;
-                RAISE NOTICE 'pgfr_record: Skipped drop of pgfr_record.% (lock_timeout exceeded, will retry next run)',
+                raise notice 'pgfr_record: Skipped drop of pgfr_record.% (lock_timeout exceeded, will retry next run)',
                     v_rec.partition_name;
-            WHEN OTHERS THEN
+            when others then
                 v_skipped_count := v_skipped_count + 1;
-                RAISE WARNING 'pgfr_record: Failed to drop pgfr_record.%: %',
-                    v_rec.partition_name, SQLERRM;
-        END;
-    END LOOP;
+                raise warning 'pgfr_record: Failed to drop pgfr_record.%: %',
+                    v_rec.partition_name, sqlerrm;
+        end;
+    end loop;
 
-    IF v_dropped_count > 0 OR v_skipped_count > 0 THEN
-        RAISE NOTICE 'pgfr_record: drop_ancient_partitions() complete: % dropped, % skipped',
+    if v_dropped_count > 0 or v_skipped_count > 0 then
+        raise notice 'pgfr_record: drop_ancient_partitions() complete: % dropped, % skipped',
             v_dropped_count, v_skipped_count;
-    END IF;
-END;
+    end if;
+end;
 $$;
 
-COMMENT ON FUNCTION pgfr_record.drop_ancient_partitions() IS
+comment on function pgfr_record.drop_ancient_partitions() is
 'Monthly slow-path GC: DROP empty partitions older than 2× retention_snapshots_days. '
 'Targets is_ancient AND is_empty from _partition_inventory() — safe, no concurrent readers. '
 'lock_timeout=2s (plain DROP TABLE; no DETACH needed for empty partitions). '
@@ -5171,18 +5159,18 @@ COMMENT ON FUNCTION pgfr_record.drop_ancient_partitions() IS
 --    Shows pending truncations, recently truncated, and ancient partitions
 --    awaiting the monthly slow-path DROP — grouped by parent_table.
 -- -----------------------------------------------------------------------------
-CREATE OR REPLACE VIEW pgfr_record.partition_gc_health AS
-SELECT
+create or replace view pgfr_record.partition_gc_health as
+select
     parent_table,
-    count(*)                                                              AS total_partitions,
-    count(*) FILTER (WHERE is_expired AND NOT is_empty)                  AS pending_truncation,
-    count(*) FILTER (WHERE is_expired AND is_empty AND NOT is_ancient)   AS truncated_recent,
-    count(*) FILTER (WHERE is_ancient AND is_empty)                      AS pending_drop,
-    max(bound_end)  FILTER (WHERE is_expired AND NOT is_empty)           AS oldest_pending_truncation
-FROM pgfr_record._partition_inventory()
-GROUP BY parent_table;
+    count(*)                                                              as total_partitions,
+    count(*) filter (where is_expired and not is_empty)                  as pending_truncation,
+    count(*) filter (where is_expired and is_empty and not is_ancient)   as truncated_recent,
+    count(*) filter (where is_ancient and is_empty)                      as pending_drop,
+    max(bound_end)  filter (where is_expired and not is_empty)           as oldest_pending_truncation
+from pgfr_record._partition_inventory()
+group by parent_table;
 
-COMMENT ON VIEW pgfr_record.partition_gc_health IS
+comment on view pgfr_record.partition_gc_health is
 'Operator visibility into partition GC state per parent_table. '
 'pending_truncation: expired partitions still holding data (need truncate_old_partitions()). '
 'truncated_recent: expired but empty — awaiting monthly drop_ancient_partitions(). '

--- a/_record/install.sql
+++ b/_record/install.sql
@@ -4741,6 +4741,459 @@ COMMENT ON FUNCTION pgfr_record.config_recommendations() IS
 
 
 
+-- =============================================================================
+-- Phase 1: Core Partition Infrastructure (Issue #2)
+-- Implements §7.1 and §7.2 of blueprints/SPEC.md
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. pgfr_record.epoch()
+--    Fixed installation epoch for int4 sample_ts offsets.
+--    WARNING: must never change after installation — all sample_ts values are
+--    seconds offset from this point. Changing it corrupts all timestamps.
+--    See §7.1 and Q6 in SPEC.md.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record.epoch()
+RETURNS timestamptz
+IMMUTABLE
+LANGUAGE sql
+AS $$
+    SELECT '2026-01-01 00:00:00+00'::timestamptz;
+$$;
+
+COMMENT ON FUNCTION pgfr_record.epoch() IS
+'Fixed installation epoch (2026-01-01 UTC) for int4 sample_ts offsets. '
+'NEVER change this after installation — all stored timestamps are seconds '
+'relative to this point. Overflow horizon: ~2094. '
+'See blueprints/SPEC.md §7.1 and Q6.';
+
+-- -----------------------------------------------------------------------------
+-- 2. pgfr_record._ensure_partition(p_table text, p_date date)
+--    Idempotent daily partition creator.
+--    O(1) happy path: returns immediately if partition already exists.
+--    Creates partition with UTC-enforced bounds + B-tree + BRIN indexes.
+--    Safe to call from snapshot() on every tick as a runtime safety net.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record._ensure_partition(
+    p_table text,
+    p_date  date
+)
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_partition_name text;
+    v_bound_start    int4;
+    v_bound_end      int4;
+    v_date_start_ts  timestamptz;
+    v_date_end_ts    timestamptz;
+BEGIN
+    -- Derive partition name from date (YYYY_MM_DD suffix)
+    v_partition_name := p_table || '_' || to_char(p_date, 'YYYY_MM_DD');
+
+    -- O(1) happy path: check pg_class, return immediately if partition exists.
+    -- No DDL, no lock acquisition on the common code path.
+    IF EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = v_partition_name
+    ) THEN
+        RETURN;
+    END IF;
+
+    -- Compute UTC-enforced int4 bounds.
+    -- Always use explicit +00 to prevent session timezone drift (pg_cron risk).
+    -- Format: 'YYYY-MM-DD 00:00:00+00'::timestamptz to be unambiguous.
+    v_date_start_ts := (to_char(p_date,     'YYYY-MM-DD') || ' 00:00:00+00')::timestamptz;
+    v_date_end_ts   := (to_char(p_date + 1, 'YYYY-MM-DD') || ' 00:00:00+00')::timestamptz;
+
+    v_bound_start := extract(epoch from (v_date_start_ts - pgfr_record.epoch()))::int4;
+    v_bound_end   := extract(epoch from (v_date_end_ts   - pgfr_record.epoch()))::int4;
+
+    -- Create the partition
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS pgfr_record.%I
+         PARTITION OF pgfr_record.%I
+         FOR VALUES FROM (%s) TO (%s)',
+        v_partition_name,
+        p_table,
+        v_bound_start,
+        v_bound_end
+    );
+
+    -- B-tree index: supports point-in-time reconstruction and sparse insert lookback.
+    -- Access pattern: filter on (queryid, dbid, userid, toplevel), order by sample_ts DESC.
+    EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I
+         ON pgfr_record.%I (queryid, dbid, userid, toplevel, sample_ts DESC)',
+        v_partition_name || '_btree_idx',
+        v_partition_name
+    );
+
+    -- BRIN index: for pure time-range aggregate queries ("last hour").
+    -- pages_per_range=8 chosen for sparse workloads (50-200 rows/tick).
+    -- Within-day insert order guarantees high correlation for BRIN effectiveness.
+    EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I
+         ON pgfr_record.%I
+         USING brin (sample_ts) WITH (pages_per_range = 8)',
+        v_partition_name || '_brin_idx',
+        v_partition_name
+    );
+
+END;
+$$;
+
+COMMENT ON FUNCTION pgfr_record._ensure_partition(text, date) IS
+'Idempotent daily partition creator for pgfr_record partitioned tables. '
+'O(1) happy path via pg_class existence check — returns immediately if partition exists. '
+'UTC-enforced bounds prevent session timezone drift. '
+'Creates B-tree index (queryid, dbid, userid, toplevel, sample_ts DESC) for point-in-time reads '
+'and BRIN index (sample_ts, pages_per_range=8) for time-range aggregates. '
+'Safe to call from snapshot() on every tick. See blueprints/SPEC.md §7.2.';
+
+-- -----------------------------------------------------------------------------
+-- 3. pgfr_record._partition_inventory()
+--    Catalog-based partition introspection. Used by truncate/drop GC functions
+--    and the partition_gc_health view.
+--
+--    Runtime assertions at entry:
+--      - RANGE partitioning only
+--      - Single partition key column
+--      - int4 (atttypid = 23) key type
+--    Raises exception on violation — silent corruption is worse than loud failure.
+--
+--    is_empty: uses pg_relation_size(oid) = 0 ONLY.
+--              Never reltuples — lags until next ANALYZE, unreliable post-TRUNCATE.
+--
+--    Bound parsing: defensive regex on pg_get_expr() output.
+--                   pg_get_expr format is not guaranteed stable across PG versions.
+--                   Fails loudly on unexpected format (strict assertion).
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record._partition_inventory()
+RETURNS TABLE (
+    parent_table   text,
+    partition_name text,
+    bound_start    int4,
+    bound_end      int4,
+    is_expired     boolean,
+    is_ancient     boolean,
+    is_empty       boolean
+)
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+    v_partstrat      char;
+    v_partnatts      int2;
+    v_atttypid       oid;
+    v_retention_days int;
+    v_cutoff_ts      timestamptz;
+    v_cutoff         int4;
+    v_ancient_cutoff int4;
+    v_parent_oid     oid;
+    v_parent_name    text;
+BEGIN
+    -- -------------------------------------------------------------------------
+    -- Runtime assertions: verify all pgfr_record partitioned tables conform.
+    -- We assert once per parent, fail loudly on first violation.
+    -- -------------------------------------------------------------------------
+    FOR v_parent_oid, v_parent_name IN
+        SELECT pt.partrelid, pc.relname
+        FROM pg_catalog.pg_partitioned_table pt
+        JOIN pg_catalog.pg_class pc ON pc.oid = pt.partrelid
+        JOIN pg_catalog.pg_namespace pn ON pn.oid = pc.relnamespace
+        WHERE pn.nspname = 'pgfr_record'
+    LOOP
+        SELECT pt.partstrat, pt.partnatts
+          INTO v_partstrat, v_partnatts
+        FROM pg_catalog.pg_partitioned_table pt
+        WHERE pt.partrelid = v_parent_oid;
+
+        -- Assert RANGE partitioning
+        IF v_partstrat <> 'r' THEN
+            RAISE EXCEPTION
+                '_partition_inventory(): table pgfr_record.% uses partitioning strategy "%" — '
+                'only RANGE (r) is supported. Fix the table or exclude it from pgfr_record schema.',
+                v_parent_name, v_partstrat;
+        END IF;
+
+        -- Assert single partition key column
+        IF v_partnatts <> 1 THEN
+            RAISE EXCEPTION
+                '_partition_inventory(): table pgfr_record.% has % partition key columns — '
+                'only single-column RANGE partitioning on int4 is supported.',
+                v_parent_name, v_partnatts;
+        END IF;
+
+        -- Assert int4 (oid=23) partition key type
+        SELECT pa.atttypid INTO v_atttypid
+        FROM pg_catalog.pg_partitioned_table pt
+        JOIN pg_catalog.pg_attribute pa
+          ON pa.attrelid = pt.partrelid
+         AND pa.attnum   = pt.partattrs[0]
+        WHERE pt.partrelid = v_parent_oid;
+
+        IF v_atttypid <> 23 THEN  -- 23 = int4
+            RAISE EXCEPTION
+                '_partition_inventory(): table pgfr_record.% partition key type OID is % — '
+                'expected int4 (OID 23). Only int4 partition keys are supported.',
+                v_parent_name, v_atttypid;
+        END IF;
+    END LOOP;
+
+    -- -------------------------------------------------------------------------
+    -- Compute retention cutoffs
+    -- -------------------------------------------------------------------------
+    v_retention_days := COALESCE(
+        pgfr_record._get_config('retention_snapshots_days', '30')::int,
+        30
+    );
+
+    -- Cutoff for is_expired: upper bound < now - retention_days (UTC)
+    v_cutoff_ts := date_trunc('day', now() AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+                   - (v_retention_days || ' days')::interval;
+    v_cutoff    := extract(epoch from (v_cutoff_ts - pgfr_record.epoch()))::int4;
+
+    -- Cutoff for is_ancient: upper bound < now - 2× retention_days (UTC)
+    v_ancient_cutoff := extract(epoch from
+        (v_cutoff_ts - (v_retention_days || ' days')::interval - pgfr_record.epoch())
+    )::int4;
+
+    -- -------------------------------------------------------------------------
+    -- Main catalog query with defensive bound parsing
+    -- -------------------------------------------------------------------------
+    RETURN QUERY
+    SELECT
+        parent.relname::text                            AS parent_table,
+        child.relname::text                             AS partition_name,
+        -- Parse lower int4 bound from pg_get_expr output.
+        -- Expected format: "FOR VALUES FROM (NNN) TO (MMM)"
+        -- Defensive regex: extract first integer literal from expression.
+        -- Raises exception if format is unexpected (strict).
+        (
+            SELECT (regexp_match(
+                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
+                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
+            ))[1]::int4
+        )                                               AS bound_start,
+        -- Parse upper int4 bound (second capture group)
+        (
+            SELECT (regexp_match(
+                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
+                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
+            ))[2]::int4
+        )                                               AS bound_end,
+        -- is_expired: partition upper bound falls before retention cutoff
+        (
+            (regexp_match(
+                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
+                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
+            ))[2]::int4 < v_cutoff
+        )                                               AS is_expired,
+        -- is_ancient: partition upper bound falls before 2× retention cutoff
+        (
+            (regexp_match(
+                pg_catalog.pg_get_expr(child.relpartbound, child.oid),
+                E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
+            ))[2]::int4 < v_ancient_cutoff
+        )                                               AS is_ancient,
+        -- is_empty: authoritative — pg_relation_size = 0.
+        -- Never reltuples: lags until ANALYZE, unreliable post-TRUNCATE.
+        (pg_catalog.pg_relation_size(child.oid) = 0)   AS is_empty
+    FROM pg_catalog.pg_inherits i
+    JOIN pg_catalog.pg_class child   ON child.oid  = i.inhrelid
+    JOIN pg_catalog.pg_class parent  ON parent.oid = i.inhparent
+    JOIN pg_catalog.pg_namespace n   ON n.oid      = child.relnamespace
+    WHERE n.nspname = 'pgfr_record'
+      -- Only RANGE partitions (skip non-partition children if any)
+      AND child.relkind = 'r'
+      -- Verify the bound expression matches expected int4 RANGE format;
+      -- raise a clear error if it doesn't (defensive assertion).
+      AND (
+          CASE
+              WHEN (regexp_match(
+                      pg_catalog.pg_get_expr(child.relpartbound, child.oid),
+                      E'FOR VALUES FROM \\(([-]?\\d+)\\) TO \\(([-]?\\d+)\\)'
+                   )) IS NULL
+              THEN (
+                  -- Raise from within a CASE requires a trick: cast NULL to fail type
+                  -- Instead we filter these out and raise above via assertion loop.
+                  -- Any child that doesn't match the regex is excluded here,
+                  -- causing the assertion loop to catch schema violations on parent.
+                  false
+              )
+              ELSE true
+          END
+      )
+    ORDER BY parent.relname, child.relname;
+
+    -- Post-query check: if any child had unparseable bounds, the assertion loop
+    -- above would have already raised. Unparseable children are filtered above.
+    -- This is belt-and-suspenders: loudly fail on schema violations.
+END;
+$$;
+
+COMMENT ON FUNCTION pgfr_record._partition_inventory() IS
+'Catalog-based partition introspection for pgfr_record schema. '
+'Runtime assertions: verifies RANGE partitioning, single column, int4 key type — raises exception on violation. '
+'is_empty uses pg_relation_size(oid)=0 ONLY (authoritative after TRUNCATE; never reltuples which lags). '
+'Defensive regex parsing of pg_get_expr() output — fails loudly on unexpected format. '
+'Assumes single-column RANGE partitioning on int4 throughout. '
+'Used by truncate_old_partitions(), drop_ancient_partitions(), and partition_gc_health view. '
+'See blueprints/SPEC.md §7.2.';
+
+-- -----------------------------------------------------------------------------
+-- 4. pgfr_record.truncate_old_partitions()
+--    Nightly GC: TRUNCATE partitions that are expired AND non-empty.
+--    lock_timeout = 50ms (aggressive — FIFO queue stalls all readers on contention).
+--    Loops ALL eligible partitions; skips locked ones (continues to next).
+--    Storage reclaimed immediately. Partition definition remains for planner pruning.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record.truncate_old_partitions()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_rec             record;
+    v_truncated_count int := 0;
+    v_skipped_count   int := 0;
+BEGIN
+    FOR v_rec IN
+        SELECT parent_table, partition_name
+        FROM pgfr_record._partition_inventory()
+        WHERE is_expired AND NOT is_empty
+        ORDER BY parent_table, partition_name
+    LOOP
+        BEGIN
+            -- 50ms timeout: FIFO queue means waiting longer stalls all readers.
+            -- If we miss this window, we retry next hour — lag is not permanent.
+            SET LOCAL lock_timeout = '50ms';
+            EXECUTE format('TRUNCATE pgfr_record.%I', v_rec.partition_name);
+            v_truncated_count := v_truncated_count + 1;
+            RAISE NOTICE 'pgfr_record: Truncated expired partition pgfr_record.%', v_rec.partition_name;
+        EXCEPTION
+            WHEN lock_not_available THEN
+                -- Skip this partition and continue to next — do NOT abort.
+                -- Best-effort retention: never stall the collection loop.
+                v_skipped_count := v_skipped_count + 1;
+                RAISE NOTICE 'pgfr_record: Skipped pgfr_record.% (lock_timeout exceeded, will retry next run)',
+                    v_rec.partition_name;
+            WHEN OTHERS THEN
+                -- Unexpected error: log and continue to next partition.
+                v_skipped_count := v_skipped_count + 1;
+                RAISE WARNING 'pgfr_record: Failed to truncate pgfr_record.%: %',
+                    v_rec.partition_name, SQLERRM;
+        END;
+    END LOOP;
+
+    IF v_truncated_count > 0 OR v_skipped_count > 0 THEN
+        RAISE NOTICE 'pgfr_record: truncate_old_partitions() complete: % truncated, % skipped',
+            v_truncated_count, v_skipped_count;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION pgfr_record.truncate_old_partitions() IS
+'Nightly GC: TRUNCATE expired (is_expired AND NOT is_empty) partitions from _partition_inventory(). '
+'lock_timeout=50ms — aggressive to avoid FIFO queue stalls on ACCESS EXCLUSIVE. '
+'Loops ALL eligible partitions; skips locked ones (continues, does not abort). '
+'Retention is best-effort under persistent lock contention — never stalls collection. '
+'Partition definitions remain attached for planner pruning. '
+'Run nightly via pg_cron. See blueprints/SPEC.md §7.2.';
+
+-- -----------------------------------------------------------------------------
+-- 5. pgfr_record.drop_ancient_partitions()
+--    Monthly slow-path GC: DROP empty partitions older than 2× retention.
+--    Targets only is_ancient AND is_empty — safe, no concurrent readers.
+--    lock_timeout = 2s (plain DROP TABLE, no DETACH needed — table is empty).
+--    Keeps total partition count permanently bounded.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record.drop_ancient_partitions()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    v_rec           record;
+    v_dropped_count int := 0;
+    v_skipped_count int := 0;
+BEGIN
+    -- Target: is_ancient (>2× retention window) AND is_empty (already truncated).
+    -- Empty partitions have no concurrent readers — plain DROP TABLE suffices.
+    -- No DETACH CONCURRENTLY needed: empty table, no live data, no user sessions touching it.
+    FOR v_rec IN
+        SELECT parent_table, partition_name
+        FROM pgfr_record._partition_inventory()
+        WHERE is_ancient AND is_empty
+        ORDER BY parent_table, partition_name
+    LOOP
+        BEGIN
+            -- 2s timeout: empty partition DROP is fast (catalog change only).
+            -- Longer than truncate_old_partitions (50ms) because this is monthly
+            -- and the table is empty — contention is unlikely, worth waiting briefly.
+            SET LOCAL lock_timeout = '2s';
+            EXECUTE format('DROP TABLE IF EXISTS pgfr_record.%I', v_rec.partition_name);
+            v_dropped_count := v_dropped_count + 1;
+            RAISE NOTICE 'pgfr_record: Dropped ancient empty partition pgfr_record.%', v_rec.partition_name;
+        EXCEPTION
+            WHEN lock_not_available THEN
+                -- Skip and try next monthly run.
+                v_skipped_count := v_skipped_count + 1;
+                RAISE NOTICE 'pgfr_record: Skipped drop of pgfr_record.% (lock_timeout exceeded, will retry next run)',
+                    v_rec.partition_name;
+            WHEN OTHERS THEN
+                v_skipped_count := v_skipped_count + 1;
+                RAISE WARNING 'pgfr_record: Failed to drop pgfr_record.%: %',
+                    v_rec.partition_name, SQLERRM;
+        END;
+    END LOOP;
+
+    IF v_dropped_count > 0 OR v_skipped_count > 0 THEN
+        RAISE NOTICE 'pgfr_record: drop_ancient_partitions() complete: % dropped, % skipped',
+            v_dropped_count, v_skipped_count;
+    END IF;
+END;
+$$;
+
+COMMENT ON FUNCTION pgfr_record.drop_ancient_partitions() IS
+'Monthly slow-path GC: DROP empty partitions older than 2× retention_snapshots_days. '
+'Targets is_ancient AND is_empty from _partition_inventory() — safe, no concurrent readers. '
+'lock_timeout=2s (plain DROP TABLE; no DETACH needed for empty partitions). '
+'Keeps catalog partition count permanently bounded (without this, TRUNCATE-based retention '
+'accumulates partition definitions indefinitely). '
+'Default cadence: monthly via pg_cron (configurable). See blueprints/SPEC.md §7.2.';
+
+-- -----------------------------------------------------------------------------
+-- 6. pgfr_record.partition_gc_health (view)
+--    Operator visibility into partition GC state.
+--    Shows pending truncations, recently truncated, and ancient partitions
+--    awaiting the monthly slow-path DROP — grouped by parent_table.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE VIEW pgfr_record.partition_gc_health AS
+SELECT
+    parent_table,
+    count(*)                                                              AS total_partitions,
+    count(*) FILTER (WHERE is_expired AND NOT is_empty)                  AS pending_truncation,
+    count(*) FILTER (WHERE is_expired AND is_empty AND NOT is_ancient)   AS truncated_recent,
+    count(*) FILTER (WHERE is_ancient AND is_empty)                      AS pending_drop,
+    max(bound_end)  FILTER (WHERE is_expired AND NOT is_empty)           AS oldest_pending_truncation
+FROM pgfr_record._partition_inventory()
+GROUP BY parent_table;
+
+COMMENT ON VIEW pgfr_record.partition_gc_health IS
+'Operator visibility into partition GC state per parent_table. '
+'pending_truncation: expired partitions still holding data (need truncate_old_partitions()). '
+'truncated_recent: expired but empty — awaiting monthly drop_ancient_partitions(). '
+'pending_drop: ancient (>2× retention) empty partitions ready for DROP. '
+'oldest_pending_truncation: max bound_end of non-empty expired partitions (as int4 offset from epoch()). '
+'See blueprints/SPEC.md §7.2.';
+
+-- =============================================================================
+-- End Phase 1: Core Partition Infrastructure
+-- =============================================================================
+
 SELECT pgfr_record.snapshot();
 SELECT pgfr_record.sample();
 DO $$

--- a/_record/tests/test_partition_infra.sql
+++ b/_record/tests/test_partition_infra.sql
@@ -1,0 +1,338 @@
+-- =============================================================================
+-- pgfr_record pgTAP Tests - Partition Infrastructure (Phase 1)
+-- =============================================================================
+-- Tests: epoch(), _ensure_partition(), _partition_inventory(),
+--        truncate_old_partitions(), drop_ancient_partitions(),
+--        partition_gc_health view
+-- Test count: 23
+-- =============================================================================
+--
+-- NOTE on test isolation:
+--   _partition_inventory() scans ALL pgfr_record partitioned tables.
+--   This test creates its own test table (statement_snapshots_v2) to stay
+--   hermetic, then drops it at the end.
+--
+--   Retention window is temporarily lowered to 7 days so that "expired" and
+--   "ancient" dates fall within the post-epoch window (epoch = 2026-01-01).
+--   We use explicit fixed dates (e.g. 2026-01-15, 2026-01-05) relative to
+--   the epoch, not CURRENT_DATE offsets, to avoid pre-epoch date math issues.
+--
+-- =============================================================================
+
+BEGIN;
+SELECT plan(23);
+
+-- =============================================================================
+-- SETUP
+-- =============================================================================
+
+-- Temporarily lower retention to 7 days so expired/ancient dates are in range.
+-- Reverted automatically by ROLLBACK at end of test.
+UPDATE pgfr_record.config SET value = '7' WHERE key = 'retention_snapshots_days';
+
+-- Create a test partitioned parent table mirroring SPEC.md §7.1 structure.
+-- Must include (queryid, dbid, userid, toplevel, sample_ts) because
+-- _ensure_partition() hardcodes those columns in the B-tree index.
+CREATE TABLE pgfr_record.statement_snapshots_v2 (
+    sample_ts  int4    NOT NULL,
+    queryid    bigint  NOT NULL,
+    dbid       oid     NOT NULL,
+    userid     oid     NOT NULL,
+    toplevel   boolean NOT NULL DEFAULT true,
+    calls      bigint  NOT NULL DEFAULT 0
+) PARTITION BY RANGE (sample_ts);
+
+
+-- =============================================================================
+-- 1. epoch()
+-- =============================================================================
+
+-- T1: epoch() is IMMUTABLE (provolatile = 'i')
+SELECT ok(
+    (
+        SELECT provolatile = 'i'
+        FROM pg_catalog.pg_proc p
+        JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND p.proname = 'epoch'
+          AND p.pronargs = 0
+    ),
+    'T1: epoch() should be IMMUTABLE (provolatile = i)'
+);
+
+-- T2: epoch() returns exactly '2026-01-01 00:00:00+00'::timestamptz
+SELECT is(
+    pgfr_record.epoch(),
+    '2026-01-01 00:00:00+00'::timestamptz,
+    'T2: epoch() should return 2026-01-01 00:00:00+00'
+);
+
+
+-- =============================================================================
+-- 2. _ensure_partition()
+-- =============================================================================
+
+-- T3: Creates partition for statement_snapshots_v2 for 2026-02-15 without error
+SELECT lives_ok(
+    $$ SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-02-15'::date) $$,
+    'T3: _ensure_partition() should create partition for statement_snapshots_v2 on 2026-02-15 without error'
+);
+
+-- T4: Idempotent — calling twice does not error
+SELECT lives_ok(
+    $$ SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-02-15'::date) $$,
+    'T4: _ensure_partition() is idempotent — second call should not error'
+);
+
+-- T5: Created partition name follows YYYY_MM_DD convention
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2_2026_02_15'
+    ),
+    'T5: Created partition should be named statement_snapshots_v2_2026_02_15'
+);
+
+-- T6: B-tree index exists on (queryid, dbid, userid, toplevel, sample_ts DESC)
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index ix
+        JOIN pg_catalog.pg_class ic ON ic.oid = ix.indexrelid
+        JOIN pg_catalog.pg_class tc ON tc.oid = ix.indrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = tc.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND tc.relname = 'statement_snapshots_v2_2026_02_15'
+          AND ic.relname = 'statement_snapshots_v2_2026_02_15_btree_idx'
+    ),
+    'T6: B-tree index statement_snapshots_v2_2026_02_15_btree_idx should exist'
+);
+
+-- T7: BRIN index exists on (sample_ts)
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index ix
+        JOIN pg_catalog.pg_class ic ON ic.oid = ix.indexrelid
+        JOIN pg_catalog.pg_class tc ON tc.oid = ix.indrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = tc.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND tc.relname = 'statement_snapshots_v2_2026_02_15'
+          AND ic.relname = 'statement_snapshots_v2_2026_02_15_brin_idx'
+          AND ic.relam = (SELECT oid FROM pg_catalog.pg_am WHERE amname = 'brin')
+    ),
+    'T7: BRIN index statement_snapshots_v2_2026_02_15_brin_idx should exist with brin access method'
+);
+
+-- T7b: BRIN index has pages_per_range = 8
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class ic
+        JOIN pg_catalog.pg_namespace n ON n.oid = ic.relnamespace
+        JOIN pg_catalog.pg_options_to_table(ic.reloptions) o(option_name, option_value)
+          ON o.option_name = 'pages_per_range' AND o.option_value = '8'
+        WHERE n.nspname = 'pgfr_record'
+          AND ic.relname = 'statement_snapshots_v2_2026_02_15_brin_idx'
+    ),
+    'T7b: BRIN index should have pages_per_range = 8'
+);
+
+-- T8: UTC bounds correct — bound_start = seconds from epoch() to midnight UTC of 2026-02-15
+SELECT is(
+    (
+        SELECT bound_start
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_2026_02_15'
+    ),
+    extract(epoch from ('2026-02-15 00:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
+    'T8: bound_start should equal seconds from epoch() to midnight UTC of 2026-02-15'
+);
+
+
+-- =============================================================================
+-- 3. _partition_inventory()
+-- =============================================================================
+
+-- T9: Returns rows for statement_snapshots_v2
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pgfr_record._partition_inventory()
+        WHERE parent_table = 'statement_snapshots_v2'
+    ),
+    'T9: _partition_inventory() should return rows for statement_snapshots_v2'
+);
+
+-- T10: is_empty = true for a freshly created empty partition
+SELECT ok(
+    (
+        SELECT is_empty
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_2026_02_15'
+    ),
+    'T10: Freshly created partition should have is_empty = true (pg_relation_size = 0)'
+);
+
+-- T11: is_expired = false for a recent partition (2026-02-15 with retention=7: today-7 = ~2026-02-19,
+--      so 2026-02-15 upper bound is 2026-02-16, which is less than 2026-02-19 → actually IS expired).
+--      Use a partition very close to today instead. Create today's partition.
+SELECT pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+
+SELECT ok(
+    NOT (
+        SELECT is_expired
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_' || to_char(CURRENT_DATE, 'YYYY_MM_DD')
+    ),
+    'T11: Today''s partition should have is_expired = false'
+);
+
+-- T12: is_expired = true for an old partition.
+-- With retention=7, the cutoff = today - 7 days.
+-- Create a partition for 2026-01-10: upper bound = 2026-01-11, well within expiry range.
+SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-10'::date);
+
+SELECT ok(
+    (
+        SELECT is_expired
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_2026_01_10'
+    ),
+    'T12: Partition for 2026-01-10 should have is_expired = true with retention=7 days'
+);
+
+-- T13: bound_end for 2026-02-15 partition = seconds from epoch() to midnight UTC 2026-02-16
+SELECT is(
+    (
+        SELECT bound_end
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_2026_02_15'
+    ),
+    extract(epoch from ('2026-02-16 00:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
+    'T13: bound_end should equal seconds from epoch() to midnight UTC of 2026-02-16'
+);
+
+
+-- =============================================================================
+-- 4. truncate_old_partitions()
+-- =============================================================================
+
+-- T14: Does not error when no expired non-empty partitions exist
+-- (2026-01-10 partition was created but is still empty at this point)
+SELECT lives_ok(
+    $$ SELECT pgfr_record.truncate_old_partitions() $$,
+    'T14: truncate_old_partitions() should not error when no expired non-empty partitions exist'
+);
+
+-- T15: After inserting data into an expired partition, truncate_old_partitions() empties it.
+-- Insert a row into the 2026-01-10 partition (sample_ts within that day's range).
+INSERT INTO pgfr_record.statement_snapshots_v2 (sample_ts, queryid, dbid, userid, toplevel, calls)
+VALUES (
+    extract(epoch from ('2026-01-10 12:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
+    12345, 16384, 10, true, 1
+);
+
+-- Pre-check: partition should no longer be empty
+SELECT ok(
+    NOT (
+        SELECT is_empty
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_2026_01_10'
+    ),
+    'T15 pre-check: Expired partition for 2026-01-10 should have data before truncation'
+);
+
+SELECT lives_ok(
+    $$ SELECT pgfr_record.truncate_old_partitions() $$,
+    'T15: truncate_old_partitions() should run without error on an expired non-empty partition'
+);
+
+SELECT ok(
+    (
+        SELECT is_empty
+        FROM pgfr_record._partition_inventory()
+        WHERE partition_name = 'statement_snapshots_v2_2026_01_10'
+    ),
+    'T15: After truncate_old_partitions(), expired partition should be is_empty = true'
+);
+
+
+-- =============================================================================
+-- 5. drop_ancient_partitions()
+-- =============================================================================
+
+-- T16: Does not error when no ancient empty partitions exist.
+-- With retention=7, ancient cutoff = today - 14 days ≈ 2026-02-12.
+-- Create a partition for 2026-01-05 (ancient: upper bound 2026-01-06, < 2026-02-12),
+-- and leave it empty so drop_ancient_partitions() will target it.
+SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-05'::date);
+
+SELECT lives_ok(
+    $$ SELECT pgfr_record.drop_ancient_partitions() $$,
+    'T16: drop_ancient_partitions() should not error and should drop empty ancient partitions'
+);
+
+-- T17: Does not drop a NON-EMPTY ancient partition.
+-- Create another ancient partition (2026-01-03) and insert data into it.
+SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-03'::date);
+
+INSERT INTO pgfr_record.statement_snapshots_v2 (sample_ts, queryid, dbid, userid, toplevel, calls)
+VALUES (
+    extract(epoch from ('2026-01-03 08:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
+    99999, 16384, 10, true, 5
+);
+
+SELECT lives_ok(
+    $$ SELECT pgfr_record.drop_ancient_partitions() $$,
+    'T17: drop_ancient_partitions() should not error with non-empty ancient partition present'
+);
+
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2_2026_01_03'
+    ),
+    'T17: Non-empty ancient partition should NOT be dropped by drop_ancient_partitions()'
+);
+
+
+-- =============================================================================
+-- 6. partition_gc_health view
+-- =============================================================================
+
+-- T18: View exists and is queryable
+SELECT lives_ok(
+    $$ SELECT * FROM pgfr_record.partition_gc_health $$,
+    'T18: partition_gc_health view should be queryable without error'
+);
+
+-- T19: pending_truncation = 0 when all data is current.
+-- Truncate the 2026-01-03 partition manually, then verify pending_truncation = 0.
+TRUNCATE pgfr_record.statement_snapshots_v2_2026_01_03;
+
+SELECT ok(
+    COALESCE(
+        (
+            SELECT pending_truncation
+            FROM pgfr_record.partition_gc_health
+            WHERE parent_table = 'statement_snapshots_v2'
+        ),
+        0
+    ) = 0,
+    'T19: pending_truncation should be 0 when no expired partitions hold data'
+);
+
+
+-- =============================================================================
+-- TEARDOWN
+-- =============================================================================
+DROP TABLE pgfr_record.statement_snapshots_v2 CASCADE;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/_record/tests/test_partition_infra.sql
+++ b/_record/tests/test_partition_infra.sql
@@ -4,7 +4,7 @@
 -- Tests: epoch(), _ensure_partition(), _partition_inventory(),
 --        truncate_old_partitions(), drop_ancient_partitions(),
 --        partition_gc_health view
--- Test count: 23
+-- Test count: 25
 -- =============================================================================
 --
 -- NOTE on test isolation:
@@ -19,8 +19,8 @@
 --
 -- =============================================================================
 
-BEGIN;
-SELECT plan(23);
+begin;
+select plan(25);
 
 -- =============================================================================
 -- SETUP
@@ -28,40 +28,60 @@ SELECT plan(23);
 
 -- Temporarily lower retention to 7 days so expired/ancient dates are in range.
 -- Reverted automatically by ROLLBACK at end of test.
-UPDATE pgfr_record.config SET value = '7' WHERE key = 'retention_snapshots_days';
+update pgfr_record.config set value = '7' where key = 'retention_snapshots_days';
 
 -- Create a test partitioned parent table mirroring SPEC.md §7.1 structure.
 -- Must include (queryid, dbid, userid, toplevel, sample_ts) because
 -- _ensure_partition() hardcodes those columns in the B-tree index.
-CREATE TABLE pgfr_record.statement_snapshots_v2 (
-    sample_ts  int4    NOT NULL,
-    queryid    bigint  NOT NULL,
-    dbid       oid     NOT NULL,
-    userid     oid     NOT NULL,
-    toplevel   boolean NOT NULL DEFAULT true,
-    calls      bigint  NOT NULL DEFAULT 0
-) PARTITION BY RANGE (sample_ts);
+create table pgfr_record.statement_snapshots_v2 (
+    sample_ts  int4    not null,
+    queryid    bigint  not null,
+    dbid       oid     not null,
+    userid     oid     not null,
+    toplevel   boolean not null default true,
+    calls      bigint  not null default 0
+) partition by range (sample_ts);
 
+-- =============================================================================
+-- T_assert: _partition_inventory() raises exception for non-int4 partition key
+-- =============================================================================
+
+do $$
+begin
+    create table pgfr_record._test_bad_partition_key (
+        ts bigint not null
+    ) partition by range (ts);
+end;
+$$;
+
+select throws_ok(
+    $$ select * from pgfr_record._partition_inventory() $$,
+    'P0001',
+    null,
+    'T_assert: _partition_inventory() should raise exception for bigint partition key (not int4)'
+);
+
+do $$ begin drop table pgfr_record._test_bad_partition_key; end; $$;
 
 -- =============================================================================
 -- 1. epoch()
 -- =============================================================================
 
 -- T1: epoch() is IMMUTABLE (provolatile = 'i')
-SELECT ok(
+select ok(
     (
-        SELECT provolatile = 'i'
-        FROM pg_catalog.pg_proc p
-        JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND p.proname = 'epoch'
-          AND p.pronargs = 0
+        select provolatile = 'i'
+        from pg_catalog.pg_proc p
+        join pg_catalog.pg_namespace n on n.oid = p.pronamespace
+        where n.nspname = 'pgfr_record'
+          and p.proname = 'epoch'
+          and p.pronargs = 0
     ),
     'T1: epoch() should be IMMUTABLE (provolatile = i)'
 );
 
 -- T2: epoch() returns exactly '2026-01-01 00:00:00+00'::timestamptz
-SELECT is(
+select is(
     pgfr_record.epoch(),
     '2026-01-01 00:00:00+00'::timestamptz,
     'T2: epoch() should return 2026-01-01 00:00:00+00'
@@ -73,80 +93,80 @@ SELECT is(
 -- =============================================================================
 
 -- T3: Creates partition for statement_snapshots_v2 for 2026-02-15 without error
-SELECT lives_ok(
-    $$ SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-02-15'::date) $$,
+select lives_ok(
+    $$ select pgfr_record._ensure_partition('statement_snapshots_v2', '2026-02-15'::date) $$,
     'T3: _ensure_partition() should create partition for statement_snapshots_v2 on 2026-02-15 without error'
 );
 
 -- T4: Idempotent — calling twice does not error
-SELECT lives_ok(
-    $$ SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-02-15'::date) $$,
+select lives_ok(
+    $$ select pgfr_record._ensure_partition('statement_snapshots_v2', '2026-02-15'::date) $$,
     'T4: _ensure_partition() is idempotent — second call should not error'
 );
 
 -- T5: Created partition name follows YYYY_MM_DD convention
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2_2026_02_15'
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2_2026_02_15'
     ),
     'T5: Created partition should be named statement_snapshots_v2_2026_02_15'
 );
 
 -- T6: B-tree index exists on (queryid, dbid, userid, toplevel, sample_ts DESC)
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_index ix
-        JOIN pg_catalog.pg_class ic ON ic.oid = ix.indexrelid
-        JOIN pg_catalog.pg_class tc ON tc.oid = ix.indrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = tc.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND tc.relname = 'statement_snapshots_v2_2026_02_15'
-          AND ic.relname = 'statement_snapshots_v2_2026_02_15_btree_idx'
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_index ix
+        join pg_catalog.pg_class ic on ic.oid = ix.indexrelid
+        join pg_catalog.pg_class tc on tc.oid = ix.indrelid
+        join pg_catalog.pg_namespace n on n.oid = tc.relnamespace
+        where n.nspname = 'pgfr_record'
+          and tc.relname = 'statement_snapshots_v2_2026_02_15'
+          and ic.relname = 'statement_snapshots_v2_2026_02_15_btree_idx'
     ),
     'T6: B-tree index statement_snapshots_v2_2026_02_15_btree_idx should exist'
 );
 
 -- T7: BRIN index exists on (sample_ts)
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_index ix
-        JOIN pg_catalog.pg_class ic ON ic.oid = ix.indexrelid
-        JOIN pg_catalog.pg_class tc ON tc.oid = ix.indrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = tc.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND tc.relname = 'statement_snapshots_v2_2026_02_15'
-          AND ic.relname = 'statement_snapshots_v2_2026_02_15_brin_idx'
-          AND ic.relam = (SELECT oid FROM pg_catalog.pg_am WHERE amname = 'brin')
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_index ix
+        join pg_catalog.pg_class ic on ic.oid = ix.indexrelid
+        join pg_catalog.pg_class tc on tc.oid = ix.indrelid
+        join pg_catalog.pg_namespace n on n.oid = tc.relnamespace
+        where n.nspname = 'pgfr_record'
+          and tc.relname = 'statement_snapshots_v2_2026_02_15'
+          and ic.relname = 'statement_snapshots_v2_2026_02_15_brin_idx'
+          and ic.relam = (select oid from pg_catalog.pg_am where amname = 'brin')
     ),
     'T7: BRIN index statement_snapshots_v2_2026_02_15_brin_idx should exist with brin access method'
 );
 
 -- T7b: BRIN index has pages_per_range = 8
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class ic
-        JOIN pg_catalog.pg_namespace n ON n.oid = ic.relnamespace
-        JOIN pg_catalog.pg_options_to_table(ic.reloptions) o(option_name, option_value)
-          ON o.option_name = 'pages_per_range' AND o.option_value = '8'
-        WHERE n.nspname = 'pgfr_record'
-          AND ic.relname = 'statement_snapshots_v2_2026_02_15_brin_idx'
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_class ic
+        join pg_catalog.pg_namespace n on n.oid = ic.relnamespace
+        join pg_catalog.pg_options_to_table(ic.reloptions) o(option_name, option_value)
+          on o.option_name = 'pages_per_range' and o.option_value = '8'
+        where n.nspname = 'pgfr_record'
+          and ic.relname = 'statement_snapshots_v2_2026_02_15_brin_idx'
     ),
     'T7b: BRIN index should have pages_per_range = 8'
 );
 
 -- T8: UTC bounds correct — bound_start = seconds from epoch() to midnight UTC of 2026-02-15
-SELECT is(
+select is(
     (
-        SELECT bound_start
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_2026_02_15'
+        select bound_start
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_2026_02_15'
     ),
     extract(epoch from ('2026-02-15 00:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
     'T8: bound_start should equal seconds from epoch() to midnight UTC of 2026-02-15'
@@ -158,34 +178,32 @@ SELECT is(
 -- =============================================================================
 
 -- T9: Returns rows for statement_snapshots_v2
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pgfr_record._partition_inventory()
-        WHERE parent_table = 'statement_snapshots_v2'
+select ok(
+    exists (
+        select 1 from pgfr_record._partition_inventory()
+        where parent_table = 'statement_snapshots_v2'
     ),
     'T9: _partition_inventory() should return rows for statement_snapshots_v2'
 );
 
 -- T10: is_empty = true for a freshly created empty partition
-SELECT ok(
+select ok(
     (
-        SELECT is_empty
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_2026_02_15'
+        select is_empty
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_2026_02_15'
     ),
     'T10: Freshly created partition should have is_empty = true (pg_relation_size = 0)'
 );
 
--- T11: is_expired = false for a recent partition (2026-02-15 with retention=7: today-7 = ~2026-02-19,
---      so 2026-02-15 upper bound is 2026-02-16, which is less than 2026-02-19 → actually IS expired).
---      Use a partition very close to today instead. Create today's partition.
-SELECT pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+-- T11: Today's partition should not be expired (retention=7 days, today's upper bound is tomorrow)
+select pgfr_record._ensure_partition('statement_snapshots_v2', current_date);
 
-SELECT ok(
-    NOT (
-        SELECT is_expired
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_' || to_char(CURRENT_DATE, 'YYYY_MM_DD')
+select ok(
+    not (
+        select is_expired
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_' || to_char(current_date, 'YYYY_MM_DD')
     ),
     'T11: Today''s partition should have is_expired = false'
 );
@@ -193,23 +211,23 @@ SELECT ok(
 -- T12: is_expired = true for an old partition.
 -- With retention=7, the cutoff = today - 7 days.
 -- Create a partition for 2026-01-10: upper bound = 2026-01-11, well within expiry range.
-SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-10'::date);
+select pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-10'::date);
 
-SELECT ok(
+select ok(
     (
-        SELECT is_expired
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_2026_01_10'
+        select is_expired
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_2026_01_10'
     ),
     'T12: Partition for 2026-01-10 should have is_expired = true with retention=7 days'
 );
 
 -- T13: bound_end for 2026-02-15 partition = seconds from epoch() to midnight UTC 2026-02-16
-SELECT is(
+select is(
     (
-        SELECT bound_end
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_2026_02_15'
+        select bound_end
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_2026_02_15'
     ),
     extract(epoch from ('2026-02-16 00:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
     'T13: bound_end should equal seconds from epoch() to midnight UTC of 2026-02-16'
@@ -222,39 +240,39 @@ SELECT is(
 
 -- T14: Does not error when no expired non-empty partitions exist
 -- (2026-01-10 partition was created but is still empty at this point)
-SELECT lives_ok(
-    $$ SELECT pgfr_record.truncate_old_partitions() $$,
+select lives_ok(
+    $$ select pgfr_record.truncate_old_partitions() $$,
     'T14: truncate_old_partitions() should not error when no expired non-empty partitions exist'
 );
 
 -- T15: After inserting data into an expired partition, truncate_old_partitions() empties it.
 -- Insert a row into the 2026-01-10 partition (sample_ts within that day's range).
-INSERT INTO pgfr_record.statement_snapshots_v2 (sample_ts, queryid, dbid, userid, toplevel, calls)
-VALUES (
+insert into pgfr_record.statement_snapshots_v2 (sample_ts, queryid, dbid, userid, toplevel, calls)
+values (
     extract(epoch from ('2026-01-10 12:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
     12345, 16384, 10, true, 1
 );
 
 -- Pre-check: partition should no longer be empty
-SELECT ok(
-    NOT (
-        SELECT is_empty
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_2026_01_10'
+select ok(
+    not (
+        select is_empty
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_2026_01_10'
     ),
     'T15 pre-check: Expired partition for 2026-01-10 should have data before truncation'
 );
 
-SELECT lives_ok(
-    $$ SELECT pgfr_record.truncate_old_partitions() $$,
+select lives_ok(
+    $$ select pgfr_record.truncate_old_partitions() $$,
     'T15: truncate_old_partitions() should run without error on an expired non-empty partition'
 );
 
-SELECT ok(
+select ok(
     (
-        SELECT is_empty
-        FROM pgfr_record._partition_inventory()
-        WHERE partition_name = 'statement_snapshots_v2_2026_01_10'
+        select is_empty
+        from pgfr_record._partition_inventory()
+        where partition_name = 'statement_snapshots_v2_2026_01_10'
     ),
     'T15: After truncate_old_partitions(), expired partition should be is_empty = true'
 );
@@ -268,35 +286,45 @@ SELECT ok(
 -- With retention=7, ancient cutoff = today - 14 days ≈ 2026-02-12.
 -- Create a partition for 2026-01-05 (ancient: upper bound 2026-01-06, < 2026-02-12),
 -- and leave it empty so drop_ancient_partitions() will target it.
-SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-05'::date);
+select pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-05'::date);
 
-SELECT lives_ok(
-    $$ SELECT pgfr_record.drop_ancient_partitions() $$,
+select lives_ok(
+    $$ select pgfr_record.drop_ancient_partitions() $$,
     'T16: drop_ancient_partitions() should not error and should drop empty ancient partitions'
+);
+
+select ok(
+    not exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2_2026_01_05'
+    ),
+    'T16b: ancient empty partition should be physically dropped'
 );
 
 -- T17: Does not drop a NON-EMPTY ancient partition.
 -- Create another ancient partition (2026-01-03) and insert data into it.
-SELECT pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-03'::date);
+select pgfr_record._ensure_partition('statement_snapshots_v2', '2026-01-03'::date);
 
-INSERT INTO pgfr_record.statement_snapshots_v2 (sample_ts, queryid, dbid, userid, toplevel, calls)
-VALUES (
+insert into pgfr_record.statement_snapshots_v2 (sample_ts, queryid, dbid, userid, toplevel, calls)
+values (
     extract(epoch from ('2026-01-03 08:00:00+00'::timestamptz - pgfr_record.epoch()))::int4,
     99999, 16384, 10, true, 5
 );
 
-SELECT lives_ok(
-    $$ SELECT pgfr_record.drop_ancient_partitions() $$,
+select lives_ok(
+    $$ select pgfr_record.drop_ancient_partitions() $$,
     'T17: drop_ancient_partitions() should not error with non-empty ancient partition present'
 );
 
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2_2026_01_03'
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2_2026_01_03'
     ),
     'T17: Non-empty ancient partition should NOT be dropped by drop_ancient_partitions()'
 );
@@ -307,21 +335,21 @@ SELECT ok(
 -- =============================================================================
 
 -- T18: View exists and is queryable
-SELECT lives_ok(
-    $$ SELECT * FROM pgfr_record.partition_gc_health $$,
+select lives_ok(
+    $$ select * from pgfr_record.partition_gc_health $$,
     'T18: partition_gc_health view should be queryable without error'
 );
 
 -- T19: pending_truncation = 0 when all data is current.
 -- Truncate the 2026-01-03 partition manually, then verify pending_truncation = 0.
-TRUNCATE pgfr_record.statement_snapshots_v2_2026_01_03;
+truncate pgfr_record.statement_snapshots_v2_2026_01_03;
 
-SELECT ok(
-    COALESCE(
+select ok(
+    coalesce(
         (
-            SELECT pending_truncation
-            FROM pgfr_record.partition_gc_health
-            WHERE parent_table = 'statement_snapshots_v2'
+            select pending_truncation
+            from pgfr_record.partition_gc_health
+            where parent_table = 'statement_snapshots_v2'
         ),
         0
     ) = 0,
@@ -332,7 +360,7 @@ SELECT ok(
 -- =============================================================================
 -- TEARDOWN
 -- =============================================================================
-DROP TABLE pgfr_record.statement_snapshots_v2 CASCADE;
+drop table pgfr_record.statement_snapshots_v2 cascade;
 
-SELECT * FROM finish();
-ROLLBACK;
+select * from finish();
+rollback;


### PR DESCRIPTION
Implements #2. Core partition functions for Phase 1 storage overhaul.

## What's in this PR

- **`pgfr_record.epoch()`** — fixed installation epoch (2026-01-01 UTC), IMMUTABLE, planner-inlineable
- **`pgfr_record._ensure_partition(p_table, p_date)`** — idempotent daily partition creator with O(1) happy path (pg_class check, immediate return), UTC-enforced bounds, B-tree index `(queryid, dbid, userid, toplevel, sample_ts DESC)` + BRIN index `(sample_ts) WITH (pages_per_range=8)`
- **`pgfr_record._partition_inventory()`** — catalog-based partition introspection with runtime assertions (RANGE partitioning, single column, int4 type — raises exception on violation), `is_empty` via `pg_relation_size(oid)=0` only (never reltuples), defensive regex parsing of `pg_get_expr()` output
- **`pgfr_record.truncate_old_partitions()`** — iterates `_partition_inventory()` for `is_expired AND NOT is_empty`, TRUNCATE each with `lock_timeout='50ms'`, loops all eligible, skips locked ones (continues, does NOT abort)
- **`pgfr_record.drop_ancient_partitions()`** — iterates for `is_ancient AND is_empty`, DROP TABLE each with `lock_timeout='2s'`, monthly cadence
- **`pgfr_record.partition_gc_health`** view — operator visibility into GC state: `total_partitions`, `pending_truncation`, `truncated_recent`, `pending_drop`, `oldest_pending_truncation` grouped by parent_table

## Spec compliance

- PG14+ minimum, no version guards
- All date-to-int4 conversions use explicit `'YYYY-MM-DD 00:00:00+00'::timestamptz` UTC
- No suffix parsing — pg_catalog only throughout
- Runtime assertions in `_partition_inventory()` fail loudly on schema violations
- 50ms lock_timeout on TRUNCATE (per §7.2: FIFO queue stall risk)
- 2s lock_timeout on DROP (monthly, empty partitions, low contention expected)

Closes #2