### PR TITLE
feat(phase1): sparse statement_snapshots collector + statement_last_state

### DIFF
--- a/_record/install.sql
+++ b/_record/install.sql
@@ -4784,3 +4784,396 @@ BEGIN
     RAISE NOTICE '';
 END;
 $$;
+-- =============================================================================
+-- Phase 1: Sparse statement_snapshots collector
+-- SPEC §5.2 — storage-overhaul-spec branch
+-- PG14+ minimum (requires pg_stat_statements_info, toplevel column)
+-- =============================================================================
+
+-- ---------------------------------------------------------------------------
+-- 1. Epoch function (borrowed from pg_ash pattern in SPEC §7.1)
+--    WARNING: must never change after installation — all sample_ts values are
+--    seconds offset from this point. Changing it corrupts all timestamps.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record.epoch()
+RETURNS TIMESTAMPTZ IMMUTABLE LANGUAGE sql AS
+$$SELECT '2026-01-01 00:00:00+00'::timestamptz$$;
+COMMENT ON FUNCTION pgfr_record.epoch() IS
+'Fixed installation epoch for int4 sample_ts offset arithmetic. '
+'WARNING: must never change after installation — all stored sample_ts values '
+'are seconds since this point. Overflow ~2094. See SPEC §7.1.';
+
+-- ---------------------------------------------------------------------------
+-- 2. statement_snapshots_v2  — partitioned by range (sample_ts int4)
+--    Dual-write: old statement_snapshots stays untouched (see SPEC Q2)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS pgfr_record.statement_snapshots_v2 (
+    snapshot_id             BIGINT          NOT NULL,  -- BIGINT per SPEC Q5; accepts INT serial values safely
+    sample_ts               INT4            NOT NULL,  -- seconds since pgfr_record.epoch()
+    queryid                 BIGINT          NOT NULL,
+    userid                  OID             NOT NULL,
+    dbid                    OID             NOT NULL,
+    toplevel                BOOLEAN         NOT NULL,  -- PG14+; part of PGSS uniqueness key
+    query_preview           TEXT,
+    calls                   BIGINT,
+    total_exec_time         DOUBLE PRECISION,
+    min_exec_time           DOUBLE PRECISION,
+    max_exec_time           DOUBLE PRECISION,
+    mean_exec_time          DOUBLE PRECISION,
+    rows                    BIGINT,
+    shared_blks_hit         BIGINT,
+    shared_blks_read        BIGINT,
+    shared_blks_dirtied     BIGINT,
+    shared_blks_written     BIGINT,
+    temp_blks_read          BIGINT,
+    temp_blks_written       BIGINT,
+    blk_read_time           DOUBLE PRECISION,
+    blk_write_time          DOUBLE PRECISION,
+    wal_records             BIGINT,
+    wal_bytes               NUMERIC,
+    pgss_dealloc_warning    BOOLEAN         NOT NULL DEFAULT FALSE  -- cluster-level PGSS eviction event
+) PARTITION BY RANGE (sample_ts);
+
+COMMENT ON TABLE pgfr_record.statement_snapshots_v2 IS
+'Sparse PGSS history partitioned by int4 sample_ts (seconds since pgfr_record.epoch()). '
+'Dual-write: old statement_snapshots retained. Missing row = no change since last stored row. '
+'Readers reconstruct full state via DISTINCT ON ... ORDER BY sample_ts DESC. '
+'See SPEC §5.2.';
+
+COMMENT ON COLUMN pgfr_record.statement_snapshots_v2.pgss_dealloc_warning IS
+'TRUE when pg_stat_statements_info.dealloc increased since last tick. '
+'This is a CLUSTER-WIDE signal: evictions on any database set this flag. '
+'Do NOT interpret as "data for this database is missing" — say "cluster-level PGSS evictions".';
+
+-- ---------------------------------------------------------------------------
+-- 3. statement_last_state — UNLOGGED HOT-optimized side table
+-- ---------------------------------------------------------------------------
+CREATE UNLOGGED TABLE IF NOT EXISTS pgfr_record.statement_last_state (
+    queryid     BIGINT  NOT NULL,
+    dbid        OID     NOT NULL,
+    userid      OID     NOT NULL,
+    toplevel    BOOLEAN NOT NULL,  -- PG14+; part of PGSS uniqueness key
+    calls       BIGINT  NOT NULL,
+    sample_ts   INT4    NOT NULL,
+    PRIMARY KEY (queryid, dbid, userid, toplevel)
+) WITH (
+    fillfactor = 70,                        -- leave room for HOT updates
+    autovacuum_vacuum_scale_factor  = 0.01, -- vacuum after 1% dead tuples
+    autovacuum_analyze_scale_factor = 0.01
+);
+
+COMMENT ON TABLE pgfr_record.statement_last_state IS
+'HOT-sensitive: do NOT index mutable columns (calls, sample_ts). '
+'HOT updates require changed columns to be unindexed. '
+'See: https://github.com/NikolayS/pg-flight-recorder/blueprints/SPEC.md §5.2';
+
+-- ---------------------------------------------------------------------------
+-- 4. _rebuild_statement_last_state()
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record._rebuild_statement_last_state()
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+BEGIN
+    TRUNCATE pgfr_record.statement_last_state;
+    INSERT INTO pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
+    SELECT
+        queryid,
+        dbid,
+        userid,
+        toplevel,
+        calls,
+        EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4
+    FROM pg_stat_statements;
+    ANALYZE pgfr_record.statement_last_state;
+END;
+$$;
+COMMENT ON FUNCTION pgfr_record._rebuild_statement_last_state() IS
+'Full rebuild of statement_last_state from pg_stat_statements. '
+'Called on crash recovery (UNLOGGED table empty) or clean-restart desync '
+'(PGSS stats_reset newer than max(sample_ts) in last_state). '
+'Caller must hold pg_try_advisory_xact_lock before calling. '
+'ANALYZE is called immediately to lock in planner statistics post-TRUNCATE.';
+
+-- ---------------------------------------------------------------------------
+-- 5. _ensure_partition_v2() — O(1) on happy path, creates partition if missing
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record._ensure_partition_v2(p_date DATE DEFAULT CURRENT_DATE)
+RETURNS TEXT
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_partition_name    TEXT;
+    v_bound_start       INT4;
+    v_bound_end         INT4;
+    v_date_str          TEXT;
+BEGIN
+    -- Always compute bounds in UTC to avoid session timezone drift (SPEC §7.1)
+    v_date_str       := TO_CHAR(p_date, 'YYYY_MM_DD');
+    v_partition_name := 'statement_snapshots_v2_' || v_date_str;
+
+    -- O(1) happy path: return immediately if partition already exists
+    IF EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = v_partition_name
+    ) THEN
+        RETURN v_partition_name;
+    END IF;
+
+    -- Compute int4 bounds from UTC dates
+    v_bound_start := EXTRACT(EPOCH FROM (p_date::TIMESTAMPTZ AT TIME ZONE 'UTC') - pgfr_record.epoch())::INT4;
+    v_bound_end   := EXTRACT(EPOCH FROM ((p_date + 1)::TIMESTAMPTZ AT TIME ZONE 'UTC') - pgfr_record.epoch())::INT4;
+
+    EXECUTE format(
+        'CREATE TABLE IF NOT EXISTS pgfr_record.%I
+         PARTITION OF pgfr_record.statement_snapshots_v2
+         FOR VALUES FROM (%L) TO (%L)',
+        v_partition_name, v_bound_start, v_bound_end
+    );
+
+    -- B-tree for point-in-time reconstruction (SPEC §7.1)
+    EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I ON pgfr_record.%I (queryid, dbid, userid, sample_ts DESC)',
+        v_partition_name || '_qtud_idx', v_partition_name
+    );
+
+    -- BRIN for pure time-range queries; pages_per_range=8 per SPEC §7.1 guidance
+    EXECUTE format(
+        'CREATE INDEX IF NOT EXISTS %I ON pgfr_record.%I USING BRIN (sample_ts) WITH (pages_per_range = 8)',
+        v_partition_name || '_ts_brin', v_partition_name
+    );
+
+    RETURN v_partition_name;
+END;
+$$;
+COMMENT ON FUNCTION pgfr_record._ensure_partition_v2(DATE) IS
+'Idempotent: creates daily partition + indexes for statement_snapshots_v2 if missing. '
+'O(1) on happy path (single catalog lookup). Safe to call every tick as a runtime safety net.';
+
+-- ---------------------------------------------------------------------------
+-- 6. _collect_statement_snapshot_sparse() — the core sparse collector
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pgfr_record._collect_statement_snapshot_sparse(p_snapshot_id BIGINT)
+RETURNS VOID
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_sample_ts         INT4;
+    v_pgss_reset        TIMESTAMPTZ;
+    v_last_sample_ts    INT4;
+    v_last_dealloc      BIGINT;
+    v_curr_dealloc      BIGINT;
+    v_dealloc_warning   BOOLEAN := FALSE;
+    v_last_state_day    INT4;
+    v_today_start_ts    INT4;
+    v_at_boundary       BOOLEAN := FALSE;
+    v_locked            BOOLEAN;
+    v_rows_inserted     INT;
+BEGIN
+    -- Ensure partition exists for today (O(1) on happy path)
+    PERFORM pgfr_record._ensure_partition_v2(CURRENT_DATE);
+
+    v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
+
+    -- -----------------------------------------------------------------------
+    -- PGSS collection section — wrapped in BEGIN/EXCEPTION so failure here
+    -- does not abort other collection sections (SPEC §5.2)
+    -- -----------------------------------------------------------------------
+    BEGIN
+
+        -- -------------------------------------------------------------------
+        -- Step 1: Check clean-restart desync (SPEC §5.2)
+        --         pg_stat_statements_info.stats_reset is PG14+ (always present
+        --         per §2 minimum version requirement)
+        -- -------------------------------------------------------------------
+        SELECT stats_reset INTO v_pgss_reset FROM pg_stat_statements_info;
+        SELECT MAX(sample_ts) INTO v_last_sample_ts FROM pgfr_record.statement_last_state;
+
+        -- -------------------------------------------------------------------
+        -- Step 2: Check PGSS dealloc counter (cluster-wide, not per-db)
+        -- -------------------------------------------------------------------
+        SELECT dealloc INTO v_curr_dealloc FROM pg_stat_statements_info;
+        SELECT value::BIGINT INTO v_last_dealloc
+        FROM pgfr_record.config
+        WHERE key = 'pgss_last_dealloc';
+
+        IF v_last_dealloc IS NOT NULL AND v_curr_dealloc > v_last_dealloc THEN
+            v_dealloc_warning := TRUE;
+        END IF;
+        -- Store current dealloc for next tick comparison
+        INSERT INTO pgfr_record.config (key, value, updated_at)
+        VALUES ('pgss_last_dealloc', v_curr_dealloc::TEXT, now())
+        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+
+        -- -------------------------------------------------------------------
+        -- Step 3: Decide if rebuild is needed
+        --         Conditions:
+        --           (a) last_state is empty (crash recovery — UNLOGGED truncated)
+        --           (b) PGSS stats_reset is newer than our last sample_ts
+        --               (clean restart with pg_stat_statements.save=off, or
+        --                explicit pg_stat_statements_reset())
+        -- -------------------------------------------------------------------
+        IF v_last_sample_ts IS NULL
+           OR (v_pgss_reset IS NOT NULL
+               AND v_pgss_reset > (pgfr_record.epoch() + v_last_sample_ts * INTERVAL '1 second'))
+        THEN
+            -- Advisory lock prevents two concurrent callers from both rebuilding.
+            -- Lock held for entire transaction (intentional per SPEC §5.2).
+            v_locked := pg_try_advisory_xact_lock(hashtext('pgfr_last_state_rebuild'));
+            IF NOT v_locked THEN
+                -- Another session is rebuilding; skip this tick
+                INSERT INTO pgfr_record.config (key, value, updated_at)
+                VALUES ('pgss_rebuild_skip_count',
+                        (COALESCE((SELECT value FROM pgfr_record.config WHERE key = 'pgss_rebuild_skip_count'), '0')::BIGINT + 1)::TEXT,
+                        now())
+                ON CONFLICT (key) DO UPDATE
+                    SET value = (COALESCE(pgfr_record.config.value, '0')::BIGINT + 1)::TEXT,
+                        updated_at = EXCLUDED.updated_at;
+                RETURN;
+            END IF;
+            PERFORM pgfr_record._rebuild_statement_last_state();
+            -- After rebuild, re-read last_sample_ts for boundary check below
+            SELECT MAX(sample_ts) INTO v_last_sample_ts FROM pgfr_record.statement_last_state;
+        END IF;
+
+        -- -------------------------------------------------------------------
+        -- Step 4: Daily partition boundary — TRUNCATE + rebuild last_state
+        --         This keeps the side table aligned with current PGSS contents
+        --         and prevents stale entries from accumulating (SPEC §5.2).
+        -- -------------------------------------------------------------------
+        v_today_start_ts := EXTRACT(EPOCH FROM (CURRENT_DATE::TIMESTAMPTZ AT TIME ZONE 'UTC') - pgfr_record.epoch())::INT4;
+
+        -- If the most recent last_state entry is from before today, we are at
+        -- the first tick of a new day partition.
+        IF v_last_sample_ts IS NOT NULL AND v_last_sample_ts < v_today_start_ts THEN
+            v_at_boundary := TRUE;
+            -- Acquire rebuild lock (if not already held from above)
+            v_locked := pg_try_advisory_xact_lock(hashtext('pgfr_last_state_rebuild'));
+            IF NOT v_locked THEN
+                INSERT INTO pgfr_record.config (key, value, updated_at)
+                VALUES ('pgss_rebuild_skip_count',
+                        (COALESCE((SELECT value FROM pgfr_record.config WHERE key = 'pgss_rebuild_skip_count'), '0')::BIGINT + 1)::TEXT,
+                        now())
+                ON CONFLICT (key) DO UPDATE
+                    SET value = (COALESCE(pgfr_record.config.value, '0')::BIGINT + 1)::TEXT,
+                        updated_at = EXCLUDED.updated_at;
+                RETURN;
+            END IF;
+            PERFORM pgfr_record._rebuild_statement_last_state();
+            SELECT MAX(sample_ts) INTO v_last_sample_ts FROM pgfr_record.statement_last_state;
+        END IF;
+
+        -- -------------------------------------------------------------------
+        -- Step 5: Hash join PGSS against last_state; insert only changed rows
+        --         Insert condition: new queryid OR calls increased OR calls dropped
+        --         (calls drop = pg_stat_statements_reset() partial/full reset)
+        -- -------------------------------------------------------------------
+        INSERT INTO pgfr_record.statement_snapshots_v2 (
+            snapshot_id,
+            sample_ts,
+            queryid,
+            userid,
+            dbid,
+            toplevel,
+            query_preview,
+            calls,
+            total_exec_time,
+            min_exec_time,
+            max_exec_time,
+            mean_exec_time,
+            rows,
+            shared_blks_hit,
+            shared_blks_read,
+            shared_blks_dirtied,
+            shared_blks_written,
+            temp_blks_read,
+            temp_blks_written,
+            blk_read_time,
+            blk_write_time,
+            wal_records,
+            wal_bytes,
+            pgss_dealloc_warning
+        )
+        SELECT
+            p_snapshot_id,
+            v_sample_ts,
+            pss.queryid,
+            pss.userid,
+            pss.dbid,
+            pss.toplevel,
+            LEFT(pss.query, 500),
+            pss.calls,
+            pss.total_exec_time,
+            pss.min_exec_time,
+            pss.max_exec_time,
+            pss.mean_exec_time,
+            pss.rows,
+            pss.shared_blks_hit,
+            pss.shared_blks_read,
+            pss.shared_blks_dirtied,
+            pss.shared_blks_written,
+            pss.temp_blks_read,
+            pss.temp_blks_written,
+            pss.blk_read_time,
+            pss.blk_write_time,
+            pss.wal_records,
+            pss.wal_bytes,
+            v_dealloc_warning
+        FROM pg_stat_statements pss
+        LEFT JOIN pgfr_record.statement_last_state ls
+            USING (queryid, dbid, userid, toplevel)
+        WHERE
+            ls.queryid IS NULL          -- first appearance (new queryid or post-rebuild baseline)
+            OR pss.calls > ls.calls     -- query was called since last tick
+            OR pss.calls < ls.calls;    -- calls dropped: pg_stat_statements_reset() occurred
+
+        GET DIAGNOSTICS v_rows_inserted = ROW_COUNT;
+
+        -- -------------------------------------------------------------------
+        -- Step 6: Upsert last_state for all rows we just saw in PGSS
+        --         Must use ON CONFLICT DO UPDATE (not DELETE+INSERT) to preserve
+        --         HOT eligibility. Only calls and sample_ts change — never key
+        --         columns — so HOT is always eligible (SPEC §5.2).
+        -- -------------------------------------------------------------------
+        IF v_at_boundary THEN
+            -- At boundary we already did a full rebuild; no incremental upsert needed
+            -- (rebuild already reflects current PGSS state)
+            NULL;
+        ELSE
+            INSERT INTO pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
+            SELECT
+                pss.queryid,
+                pss.dbid,
+                pss.userid,
+                pss.toplevel,
+                pss.calls,
+                v_sample_ts
+            FROM pg_stat_statements pss
+            ON CONFLICT (queryid, dbid, userid, toplevel) DO UPDATE
+                SET calls     = EXCLUDED.calls,
+                    sample_ts = EXCLUDED.sample_ts;
+        END IF;
+
+    EXCEPTION
+        WHEN undefined_table THEN
+            -- pg_stat_statements not loaded; do NOT truncate last_state (SPEC §5.2)
+            RAISE WARNING 'pgfr_record: pg_stat_statements unavailable (extension not loaded): %', SQLERRM;
+        WHEN OTHERS THEN
+            -- Any other failure must not abort other collection sections
+            RAISE WARNING 'pgfr_record: PGSS sparse collection failed: %', SQLERRM;
+    END;
+END;
+$$;
+COMMENT ON FUNCTION pgfr_record._collect_statement_snapshot_sparse(BIGINT) IS
+'Sparse PGSS collector per SPEC §5.2. '
+'Inserts rows into statement_snapshots_v2 only when calls changed. '
+'Maintains statement_last_state as HOT-update-friendly side table. '
+'Handles: crash recovery (UNLOGGED empty), clean-restart desync (stats_reset check), '
+'daily partition boundary (TRUNCATE+rebuild), advisory lock (skip if rebuild in flight), '
+'PGSS dealloc tracking (cluster-wide, not per-db). '
+'Wrapped in EXCEPTION block — failure does not abort other collection sections.';
+
+-- Register config keys for sparse collector observability
+INSERT INTO pgfr_record.config (key, value) VALUES
+    ('pgss_last_dealloc',       '0'),
+    ('pgss_rebuild_skip_count', '0')
+ON CONFLICT (key) DO NOTHING;

--- a/_record/install.sql
+++ b/_record/install.sql
@@ -4794,40 +4794,40 @@ $$;
 -- 2. statement_snapshots_v2  — partitioned by range (sample_ts int4)
 --    Dual-write: old statement_snapshots stays untouched (see SPEC Q2)
 -- ---------------------------------------------------------------------------
-CREATE TABLE IF NOT EXISTS pgfr_record.statement_snapshots_v2 (
-    snapshot_id             BIGINT          NOT NULL,  -- BIGINT per SPEC Q5; accepts INT serial values safely
-    sample_ts               INT4            NOT NULL,  -- seconds since pgfr_record.epoch()
-    queryid                 BIGINT          NOT NULL,
-    userid                  OID             NOT NULL,
-    dbid                    OID             NOT NULL,
-    toplevel                BOOLEAN         NOT NULL,  -- PG14+; part of PGSS uniqueness key
-    query_preview           TEXT,
-    calls                   BIGINT,
+create table if not exists pgfr_record.statement_snapshots_v2 (
+    snapshot_id             bigint          not null,  -- BIGINT per SPEC Q5; accepts INT serial values safely
+    sample_ts               INT4            not null,  -- seconds since pgfr_record.epoch()
+    queryid                 bigint          not null,
+    userid                  oid             not null,
+    dbid                    oid             not null,
+    toplevel                boolean         not null,  -- PG14+; part of PGSS uniqueness key
+    query_preview           text,
+    calls                   bigint,
     total_exec_time         DOUBLE PRECISION,
     min_exec_time           DOUBLE PRECISION,
     max_exec_time           DOUBLE PRECISION,
     mean_exec_time          DOUBLE PRECISION,
-    rows                    BIGINT,
-    shared_blks_hit         BIGINT,
-    shared_blks_read        BIGINT,
-    shared_blks_dirtied     BIGINT,
-    shared_blks_written     BIGINT,
-    temp_blks_read          BIGINT,
-    temp_blks_written       BIGINT,
+    rows                    bigint,
+    shared_blks_hit         bigint,
+    shared_blks_read        bigint,
+    shared_blks_dirtied     bigint,
+    shared_blks_written     bigint,
+    temp_blks_read          bigint,
+    temp_blks_written       bigint,
     blk_read_time           DOUBLE PRECISION,
     blk_write_time          DOUBLE PRECISION,
-    wal_records             BIGINT,
-    wal_bytes               NUMERIC,
-    pgss_dealloc_warning    BOOLEAN         NOT NULL DEFAULT FALSE  -- cluster-level PGSS eviction event
-) PARTITION BY RANGE (sample_ts);
+    wal_records             bigint,
+    wal_bytes               numeric,
+    pgss_dealloc_warning    boolean         not null default false  -- cluster-level PGSS eviction event
+) partition by range (sample_ts);
 
-COMMENT ON TABLE pgfr_record.statement_snapshots_v2 IS
+comment on table pgfr_record.statement_snapshots_v2 is
 'Sparse PGSS history partitioned by int4 sample_ts (seconds since pgfr_record.epoch()). '
 'Dual-write: old statement_snapshots retained. Missing row = no change since last stored row. '
 'Readers reconstruct full state via DISTINCT ON ... ORDER BY sample_ts DESC. '
 'See SPEC §5.2.';
 
-COMMENT ON COLUMN pgfr_record.statement_snapshots_v2.pgss_dealloc_warning IS
+comment on column pgfr_record.statement_snapshots_v2.pgss_dealloc_warning is
 'TRUE when pg_stat_statements_info.dealloc increased since last tick. '
 'This is a CLUSTER-WIDE signal: evictions on any database set this flag. '
 'Do NOT interpret as "data for this database is missing" — say "cluster-level PGSS evictions".';
@@ -4835,21 +4835,21 @@ COMMENT ON COLUMN pgfr_record.statement_snapshots_v2.pgss_dealloc_warning IS
 -- ---------------------------------------------------------------------------
 -- 3. statement_last_state — UNLOGGED HOT-optimized side table
 -- ---------------------------------------------------------------------------
-CREATE UNLOGGED TABLE IF NOT EXISTS pgfr_record.statement_last_state (
-    queryid     BIGINT  NOT NULL,
-    dbid        OID     NOT NULL,
-    userid      OID     NOT NULL,
-    toplevel    BOOLEAN NOT NULL,  -- PG14+; part of PGSS uniqueness key
-    calls       BIGINT  NOT NULL,
-    sample_ts   INT4    NOT NULL,
-    PRIMARY KEY (queryid, dbid, userid, toplevel)
-) WITH (
+create unlogged table if not exists pgfr_record.statement_last_state (
+    queryid     bigint  not null,
+    dbid        oid     not null,
+    userid      oid     not null,
+    toplevel    boolean not null,  -- PG14+; part of PGSS uniqueness key
+    calls       bigint  not null,
+    sample_ts   INT4    not null,
+    primary key (queryid, dbid, userid, toplevel)
+) with (
     fillfactor = 70,                        -- leave room for HOT updates
     autovacuum_vacuum_scale_factor  = 0.01, -- vacuum after 1% dead tuples
     autovacuum_analyze_scale_factor = 0.01
 );
 
-COMMENT ON TABLE pgfr_record.statement_last_state IS
+comment on table pgfr_record.statement_last_state is
 'HOT-sensitive: do NOT index mutable columns (calls, sample_ts). '
 'HOT updates require changed columns to be unindexed. '
 'See: https://github.com/NikolayS/pg-flight-recorder/blueprints/SPEC.md §5.2';
@@ -4857,24 +4857,24 @@ COMMENT ON TABLE pgfr_record.statement_last_state IS
 -- ---------------------------------------------------------------------------
 -- 4. _rebuild_statement_last_state()
 -- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record._rebuild_statement_last_state()
-RETURNS VOID
-LANGUAGE plpgsql AS $$
-BEGIN
-    TRUNCATE pgfr_record.statement_last_state;
-    INSERT INTO pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
-    SELECT
+create or replace function pgfr_record._rebuild_statement_last_state()
+returns void
+language plpgsql as $$
+begin
+    truncate pgfr_record.statement_last_state;
+    insert into pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
+    select
         queryid,
         dbid,
         userid,
         toplevel,
         calls,
-        EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4
-    FROM pg_stat_statements;
-    ANALYZE pgfr_record.statement_last_state;
-END;
+        extract(EPOCH from now() - pgfr_record.epoch())::INT4
+    from pg_stat_statements;
+    analyze pgfr_record.statement_last_state;
+end;
 $$;
-COMMENT ON FUNCTION pgfr_record._rebuild_statement_last_state() IS
+comment on function pgfr_record._rebuild_statement_last_state() is
 'Full rebuild of statement_last_state from pg_stat_statements. '
 'Called on crash recovery (UNLOGGED table empty) or clean-restart desync '
 '(PGSS stats_reset newer than max(sample_ts) in last_state). '
@@ -4884,56 +4884,56 @@ COMMENT ON FUNCTION pgfr_record._rebuild_statement_last_state() IS
 -- ---------------------------------------------------------------------------
 -- 5. _collect_statement_snapshot_sparse() — the core sparse collector
 -- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record._collect_statement_snapshot_sparse(p_snapshot_id BIGINT)
-RETURNS VOID
-LANGUAGE plpgsql AS $$
-DECLARE
+create or replace function pgfr_record._collect_statement_snapshot_sparse(p_snapshot_id bigint)
+returns void
+language plpgsql as $$
+declare
     v_sample_ts         INT4;
     v_pgss_reset        TIMESTAMPTZ;
     v_last_sample_ts    INT4;
-    v_last_dealloc      BIGINT;
-    v_curr_dealloc      BIGINT;
-    v_dealloc_warning   BOOLEAN := FALSE;
+    v_last_dealloc      bigint;
+    v_curr_dealloc      bigint;
+    v_dealloc_warning   boolean := false;
     v_last_state_day    INT4;
     v_today_start_ts    INT4;
-    v_at_boundary       BOOLEAN := FALSE;
-    v_locked            BOOLEAN;
+    v_at_boundary       boolean := false;
+    v_locked            boolean;
     v_rows_inserted     INT;
-BEGIN
+begin
     -- Ensure partition exists for today (O(1) on happy path)
-    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+    perform pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
 
-    v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
+    v_sample_ts := extract(EPOCH from now() - pgfr_record.epoch())::INT4;
 
     -- -----------------------------------------------------------------------
     -- PGSS collection section — wrapped in BEGIN/EXCEPTION so failure here
     -- does not abort other collection sections (SPEC §5.2)
     -- -----------------------------------------------------------------------
-    BEGIN
+    begin
 
         -- -------------------------------------------------------------------
         -- Step 1: Check clean-restart desync (SPEC §5.2)
         --         pg_stat_statements_info.stats_reset is PG14+ (always present
         --         per §2 minimum version requirement)
         -- -------------------------------------------------------------------
-        SELECT stats_reset INTO v_pgss_reset FROM pg_stat_statements_info;
-        SELECT MAX(sample_ts) INTO v_last_sample_ts FROM pgfr_record.statement_last_state;
+        select stats_reset into v_pgss_reset from pg_stat_statements_info;
+        select MAX(sample_ts) into v_last_sample_ts from pgfr_record.statement_last_state;
 
         -- -------------------------------------------------------------------
         -- Step 2: Check PGSS dealloc counter (cluster-wide, not per-db)
         -- -------------------------------------------------------------------
-        SELECT dealloc INTO v_curr_dealloc FROM pg_stat_statements_info;
-        SELECT value::BIGINT INTO v_last_dealloc
-        FROM pgfr_record.config
-        WHERE key = 'pgss_last_dealloc';
+        select dealloc into v_curr_dealloc from pg_stat_statements_info;
+        select value::bigint into v_last_dealloc
+        from pgfr_record.config
+        where key = 'pgss_last_dealloc';
 
-        IF v_last_dealloc IS NOT NULL AND v_curr_dealloc > v_last_dealloc THEN
-            v_dealloc_warning := TRUE;
-        END IF;
+        if v_last_dealloc is not null and v_curr_dealloc > v_last_dealloc then
+            v_dealloc_warning := true;
+        end if;
         -- Store current dealloc for next tick comparison
-        INSERT INTO pgfr_record.config (key, value, updated_at)
-        VALUES ('pgss_last_dealloc', v_curr_dealloc::TEXT, now())
-        ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
+        insert into pgfr_record.config (key, value, updated_at)
+        values ('pgss_last_dealloc', v_curr_dealloc::text, now())
+        on conflict (key) do update set value = EXCLUDED.value, updated_at = EXCLUDED.updated_at;
 
         -- -------------------------------------------------------------------
         -- Step 3: Decide if rebuild is needed
@@ -4943,62 +4943,62 @@ BEGIN
         --               (clean restart with pg_stat_statements.save=off, or
         --                explicit pg_stat_statements_reset())
         -- -------------------------------------------------------------------
-        IF v_last_sample_ts IS NULL
-           OR (v_pgss_reset IS NOT NULL
-               AND v_pgss_reset > (pgfr_record.epoch() + v_last_sample_ts * INTERVAL '1 second'))
-        THEN
+        if v_last_sample_ts is null
+           or (v_pgss_reset is not null
+               and v_pgss_reset > (pgfr_record.epoch() + v_last_sample_ts * interval '1 second'))
+        then
             -- Advisory lock prevents two concurrent callers from both rebuilding.
             -- Lock held for entire transaction (intentional per SPEC §5.2).
-            v_locked := pg_try_advisory_xact_lock(hashtext('pgfr_last_state_rebuild'));
-            IF NOT v_locked THEN
+            v_locked := pg_try_advisory_xact_lock(7382961::integer, hashtext('pgfr_last_state_rebuild')::integer);
+            if not v_locked then
                 -- Another session is rebuilding; skip this tick
-                INSERT INTO pgfr_record.config (key, value, updated_at)
-                VALUES ('pgss_rebuild_skip_count',
-                        (COALESCE((SELECT value FROM pgfr_record.config WHERE key = 'pgss_rebuild_skip_count'), '0')::BIGINT + 1)::TEXT,
+                insert into pgfr_record.config (key, value, updated_at)
+                values ('pgss_rebuild_skip_count',
+                        (coalesce((select value from pgfr_record.config where key = 'pgss_rebuild_skip_count'), '0')::bigint + 1)::text,
                         now())
-                ON CONFLICT (key) DO UPDATE
-                    SET value = (COALESCE(pgfr_record.config.value, '0')::BIGINT + 1)::TEXT,
+                on conflict (key) do update
+                    set value = (coalesce(pgfr_record.config.value, '0')::bigint + 1)::text,
                         updated_at = EXCLUDED.updated_at;
-                RETURN;
-            END IF;
-            PERFORM pgfr_record._rebuild_statement_last_state();
+                return;
+            end if;
+            perform pgfr_record._rebuild_statement_last_state();
             -- After rebuild, re-read last_sample_ts for boundary check below
-            SELECT MAX(sample_ts) INTO v_last_sample_ts FROM pgfr_record.statement_last_state;
-        END IF;
+            select MAX(sample_ts) into v_last_sample_ts from pgfr_record.statement_last_state;
+        end if;
 
         -- -------------------------------------------------------------------
         -- Step 4: Daily partition boundary — TRUNCATE + rebuild last_state
         --         This keeps the side table aligned with current PGSS contents
         --         and prevents stale entries from accumulating (SPEC §5.2).
         -- -------------------------------------------------------------------
-        v_today_start_ts := EXTRACT(EPOCH FROM (CURRENT_DATE::TIMESTAMPTZ AT TIME ZONE 'UTC') - pgfr_record.epoch())::INT4;
+        v_today_start_ts := extract(EPOCH from (CURRENT_DATE::TIMESTAMPTZ at TIME zone 'UTC') - pgfr_record.epoch())::INT4;
 
         -- If the most recent last_state entry is from before today, we are at
         -- the first tick of a new day partition.
-        IF v_last_sample_ts IS NOT NULL AND v_last_sample_ts < v_today_start_ts THEN
-            v_at_boundary := TRUE;
+        if v_last_sample_ts is not null and v_last_sample_ts < v_today_start_ts then
+            v_at_boundary := true;
             -- Acquire rebuild lock (if not already held from above)
-            v_locked := pg_try_advisory_xact_lock(hashtext('pgfr_last_state_rebuild'));
-            IF NOT v_locked THEN
-                INSERT INTO pgfr_record.config (key, value, updated_at)
-                VALUES ('pgss_rebuild_skip_count',
-                        (COALESCE((SELECT value FROM pgfr_record.config WHERE key = 'pgss_rebuild_skip_count'), '0')::BIGINT + 1)::TEXT,
+            v_locked := pg_try_advisory_xact_lock(7382961::integer, hashtext('pgfr_last_state_rebuild')::integer);
+            if not v_locked then
+                insert into pgfr_record.config (key, value, updated_at)
+                values ('pgss_rebuild_skip_count',
+                        (coalesce((select value from pgfr_record.config where key = 'pgss_rebuild_skip_count'), '0')::bigint + 1)::text,
                         now())
-                ON CONFLICT (key) DO UPDATE
-                    SET value = (COALESCE(pgfr_record.config.value, '0')::BIGINT + 1)::TEXT,
+                on conflict (key) do update
+                    set value = (coalesce(pgfr_record.config.value, '0')::bigint + 1)::text,
                         updated_at = EXCLUDED.updated_at;
-                RETURN;
-            END IF;
-            PERFORM pgfr_record._rebuild_statement_last_state();
-            SELECT MAX(sample_ts) INTO v_last_sample_ts FROM pgfr_record.statement_last_state;
-        END IF;
+                return;
+            end if;
+            perform pgfr_record._rebuild_statement_last_state();
+            select MAX(sample_ts) into v_last_sample_ts from pgfr_record.statement_last_state;
+        end if;
 
         -- -------------------------------------------------------------------
         -- Step 5: Hash join PGSS against last_state; insert only changed rows
         --         Insert condition: new queryid OR calls increased OR calls dropped
         --         (calls drop = pg_stat_statements_reset() partial/full reset)
         -- -------------------------------------------------------------------
-        INSERT INTO pgfr_record.statement_snapshots_v2 (
+        insert into pgfr_record.statement_snapshots_v2 (
             snapshot_id,
             sample_ts,
             queryid,
@@ -5024,14 +5024,14 @@ BEGIN
             wal_bytes,
             pgss_dealloc_warning
         )
-        SELECT
+        select
             p_snapshot_id,
             v_sample_ts,
             pss.queryid,
             pss.userid,
             pss.dbid,
             pss.toplevel,
-            LEFT(pss.query, 500),
+            left(pss.query, 500),
             pss.calls,
             pss.total_exec_time,
             pss.min_exec_time,
@@ -5049,15 +5049,15 @@ BEGIN
             pss.wal_records,
             pss.wal_bytes,
             v_dealloc_warning
-        FROM pg_stat_statements pss
-        LEFT JOIN pgfr_record.statement_last_state ls
-            USING (queryid, dbid, userid, toplevel)
-        WHERE
-            ls.queryid IS NULL          -- first appearance (new queryid or post-rebuild baseline)
-            OR pss.calls > ls.calls     -- query was called since last tick
-            OR pss.calls < ls.calls;    -- calls dropped: pg_stat_statements_reset() occurred
+        from pg_stat_statements pss
+        left join pgfr_record.statement_last_state ls
+            using (queryid, dbid, userid, toplevel)
+        where
+            ls.queryid is null          -- first appearance (new queryid or post-rebuild baseline)
+            or pss.calls > ls.calls     -- query was called since last tick
+            or pss.calls < ls.calls;    -- calls dropped: pg_stat_statements_reset() occurred
 
-        GET DIAGNOSTICS v_rows_inserted = ROW_COUNT;
+        get diagnostics v_rows_inserted = ROW_COUNT;
 
         -- -------------------------------------------------------------------
         -- Step 6: Upsert last_state for all rows we just saw in PGSS
@@ -5065,36 +5065,36 @@ BEGIN
         --         HOT eligibility. Only calls and sample_ts change — never key
         --         columns — so HOT is always eligible (SPEC §5.2).
         -- -------------------------------------------------------------------
-        IF v_at_boundary THEN
+        if v_at_boundary then
             -- At boundary we already did a full rebuild; no incremental upsert needed
             -- (rebuild already reflects current PGSS state)
-            NULL;
-        ELSE
-            INSERT INTO pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
-            SELECT
+            null;
+        else
+            insert into pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
+            select
                 pss.queryid,
                 pss.dbid,
                 pss.userid,
                 pss.toplevel,
                 pss.calls,
                 v_sample_ts
-            FROM pg_stat_statements pss
-            ON CONFLICT (queryid, dbid, userid, toplevel) DO UPDATE
-                SET calls     = EXCLUDED.calls,
+            from pg_stat_statements pss
+            on conflict (queryid, dbid, userid, toplevel) do update
+                set calls     = EXCLUDED.calls,
                     sample_ts = EXCLUDED.sample_ts;
-        END IF;
+        end if;
 
-    EXCEPTION
-        WHEN undefined_table THEN
+    exception
+        when undefined_table then
             -- pg_stat_statements not loaded; do NOT truncate last_state (SPEC §5.2)
-            RAISE WARNING 'pgfr_record: pg_stat_statements unavailable (extension not loaded): %', SQLERRM;
-        WHEN OTHERS THEN
+            raise warning 'pgfr_record: pg_stat_statements unavailable (extension not loaded): %', sqlerrm;
+        when others then
             -- Any other failure must not abort other collection sections
-            RAISE WARNING 'pgfr_record: PGSS sparse collection failed: %', SQLERRM;
-    END;
-END;
+            raise warning 'pgfr_record: PGSS sparse collection failed [%]: %', sqlstate, sqlerrm;
+    end;
+end;
 $$;
-COMMENT ON FUNCTION pgfr_record._collect_statement_snapshot_sparse(BIGINT) IS
+comment on function pgfr_record._collect_statement_snapshot_sparse(bigint) is
 'Sparse PGSS collector per SPEC §5.2. '
 'Inserts rows into statement_snapshots_v2 only when calls changed. '
 'Maintains statement_last_state as HOT-update-friendly side table. '
@@ -5104,7 +5104,13 @@ COMMENT ON FUNCTION pgfr_record._collect_statement_snapshot_sparse(BIGINT) IS
 'Wrapped in EXCEPTION block — failure does not abort other collection sections.';
 
 -- Register config keys for sparse collector observability
-INSERT INTO pgfr_record.config (key, value) VALUES
-    ('pgss_last_dealloc',       '0'),
+-- Initialize pgss_last_dealloc to current dealloc value to avoid false-positive
+-- dealloc warnings on first run (pre-existing evictions are not our fault).
+insert into pgfr_record.config (key, value, updated_at)
+select 'pgss_last_dealloc', dealloc::text, now()
+from pg_stat_statements_info
+on conflict (key) do nothing;
+
+insert into pgfr_record.config (key, value) values
     ('pgss_rebuild_skip_count', '0')
-ON CONFLICT (key) DO NOTHING;
+on conflict (key) do nothing;

--- a/_record/install.sql
+++ b/_record/install.sql
@@ -4791,19 +4791,6 @@ $$;
 -- =============================================================================
 
 -- ---------------------------------------------------------------------------
--- 1. Epoch function (borrowed from pg_ash pattern in SPEC §7.1)
---    WARNING: must never change after installation — all sample_ts values are
---    seconds offset from this point. Changing it corrupts all timestamps.
--- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record.epoch()
-RETURNS TIMESTAMPTZ IMMUTABLE LANGUAGE sql AS
-$$SELECT '2026-01-01 00:00:00+00'::timestamptz$$;
-COMMENT ON FUNCTION pgfr_record.epoch() IS
-'Fixed installation epoch for int4 sample_ts offset arithmetic. '
-'WARNING: must never change after installation — all stored sample_ts values '
-'are seconds since this point. Overflow ~2094. See SPEC §7.1.';
-
--- ---------------------------------------------------------------------------
 -- 2. statement_snapshots_v2  — partitioned by range (sample_ts int4)
 --    Dual-write: old statement_snapshots stays untouched (see SPEC Q2)
 -- ---------------------------------------------------------------------------
@@ -4895,63 +4882,7 @@ COMMENT ON FUNCTION pgfr_record._rebuild_statement_last_state() IS
 'ANALYZE is called immediately to lock in planner statistics post-TRUNCATE.';
 
 -- ---------------------------------------------------------------------------
--- 5. _ensure_partition_v2() — O(1) on happy path, creates partition if missing
--- ---------------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pgfr_record._ensure_partition_v2(p_date DATE DEFAULT CURRENT_DATE)
-RETURNS TEXT
-LANGUAGE plpgsql AS $$
-DECLARE
-    v_partition_name    TEXT;
-    v_bound_start       INT4;
-    v_bound_end         INT4;
-    v_date_str          TEXT;
-BEGIN
-    -- Always compute bounds in UTC to avoid session timezone drift (SPEC §7.1)
-    v_date_str       := TO_CHAR(p_date, 'YYYY_MM_DD');
-    v_partition_name := 'statement_snapshots_v2_' || v_date_str;
-
-    -- O(1) happy path: return immediately if partition already exists
-    IF EXISTS (
-        SELECT 1 FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = v_partition_name
-    ) THEN
-        RETURN v_partition_name;
-    END IF;
-
-    -- Compute int4 bounds from UTC dates
-    v_bound_start := EXTRACT(EPOCH FROM (p_date::TIMESTAMPTZ AT TIME ZONE 'UTC') - pgfr_record.epoch())::INT4;
-    v_bound_end   := EXTRACT(EPOCH FROM ((p_date + 1)::TIMESTAMPTZ AT TIME ZONE 'UTC') - pgfr_record.epoch())::INT4;
-
-    EXECUTE format(
-        'CREATE TABLE IF NOT EXISTS pgfr_record.%I
-         PARTITION OF pgfr_record.statement_snapshots_v2
-         FOR VALUES FROM (%L) TO (%L)',
-        v_partition_name, v_bound_start, v_bound_end
-    );
-
-    -- B-tree for point-in-time reconstruction (SPEC §7.1)
-    EXECUTE format(
-        'CREATE INDEX IF NOT EXISTS %I ON pgfr_record.%I (queryid, dbid, userid, sample_ts DESC)',
-        v_partition_name || '_qtud_idx', v_partition_name
-    );
-
-    -- BRIN for pure time-range queries; pages_per_range=8 per SPEC §7.1 guidance
-    EXECUTE format(
-        'CREATE INDEX IF NOT EXISTS %I ON pgfr_record.%I USING BRIN (sample_ts) WITH (pages_per_range = 8)',
-        v_partition_name || '_ts_brin', v_partition_name
-    );
-
-    RETURN v_partition_name;
-END;
-$$;
-COMMENT ON FUNCTION pgfr_record._ensure_partition_v2(DATE) IS
-'Idempotent: creates daily partition + indexes for statement_snapshots_v2 if missing. '
-'O(1) on happy path (single catalog lookup). Safe to call every tick as a runtime safety net.';
-
--- ---------------------------------------------------------------------------
--- 6. _collect_statement_snapshot_sparse() — the core sparse collector
+-- 5. _collect_statement_snapshot_sparse() — the core sparse collector
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION pgfr_record._collect_statement_snapshot_sparse(p_snapshot_id BIGINT)
 RETURNS VOID
@@ -4970,7 +4901,7 @@ DECLARE
     v_rows_inserted     INT;
 BEGIN
     -- Ensure partition exists for today (O(1) on happy path)
-    PERFORM pgfr_record._ensure_partition_v2(CURRENT_DATE);
+    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
 
     v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
 

--- a/_record/tests/test_sparse_collector.sql
+++ b/_record/tests/test_sparse_collector.sql
@@ -4,6 +4,13 @@
 -- Run with: pg_prove -d <dbname> _record/tests/test_sparse_collector.sql
 -- Requires: pgTAP, pg_stat_statements
 -- PG14+ minimum
+--
+-- DEPENDENCY: This test file requires that the Phase 1 partition infrastructure
+-- (PR #5 / phase1-issue1-infra) is already installed, specifically:
+--   - pgfr_record.epoch()
+--   - pgfr_record._ensure_partition(text, date)
+-- Install _record/install.sql from the phase1-issue1-infra branch first,
+-- or merge PR #5 before running these tests.
 -- =============================================================================
 
 BEGIN;
@@ -16,6 +23,7 @@ SELECT plan(24);
 DO $$
 BEGIN
     -- Create a test partition for today if needed
+    -- Requires _ensure_partition() from phase1-issue1-infra (PR #5)
     PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
 END;
 $$;

--- a/_record/tests/test_sparse_collector.sql
+++ b/_record/tests/test_sparse_collector.sql
@@ -1,0 +1,579 @@
+-- =============================================================================
+-- pgTAP tests: Phase 1 sparse statement_snapshots collector
+-- SPEC §9.13 — Phase 1 test items
+-- Run with: pg_prove -d <dbname> _record/tests/test_sparse_collector.sql
+-- Requires: pgTAP, pg_stat_statements
+-- PG14+ minimum
+-- =============================================================================
+
+BEGIN;
+
+SELECT plan(26);
+
+-- ---------------------------------------------------------------------------
+-- Helper: ensure a clean test partition exists
+-- ---------------------------------------------------------------------------
+DO $$
+BEGIN
+    -- Create a test partition for today if needed
+    PERFORM pgfr_record._ensure_partition_v2(CURRENT_DATE);
+END;
+$$;
+
+-- ===========================================================================
+-- T1: epoch() function is IMMUTABLE and returns a timestamptz
+-- ===========================================================================
+SELECT is(
+    pg_catalog.provolatile::text,
+    'i',
+    'epoch() must be IMMUTABLE'
+)
+FROM pg_catalog.pg_proc p
+JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'pgfr_record' AND p.proname = 'epoch';
+
+-- T2: epoch() returns 2026-01-01 UTC
+SELECT is(
+    pgfr_record.epoch(),
+    '2026-01-01 00:00:00+00'::timestamptz,
+    'epoch() must return 2026-01-01 00:00:00 UTC'
+);
+
+-- ===========================================================================
+-- T3: statement_snapshots_v2 table exists and is partitioned
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2'
+          AND c.relkind = 'p'  -- partitioned table
+    ),
+    'statement_snapshots_v2 must exist as a partitioned table'
+);
+
+-- T4: statement_snapshots_v2 has toplevel boolean column
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_attribute a
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2'
+          AND a.attname = 'toplevel'
+          AND a.atttypid = pg_catalog.regtype('boolean')::oid
+          AND a.attnotnull = TRUE
+    ),
+    'statement_snapshots_v2 must have toplevel boolean not null'
+);
+
+-- T5: statement_snapshots_v2 has snapshot_id as BIGINT
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_attribute a
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2'
+          AND a.attname = 'snapshot_id'
+          AND a.atttypid = pg_catalog.regtype('bigint')::oid
+    ),
+    'statement_snapshots_v2.snapshot_id must be BIGINT'
+);
+
+-- ===========================================================================
+-- T6: statement_last_state table exists and is UNLOGGED
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_last_state'
+          AND c.relpersistence = 'u'  -- unlogged
+    ),
+    'statement_last_state must exist and be UNLOGGED'
+);
+
+-- T7: statement_last_state primary key covers (queryid, dbid, userid, toplevel)
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index i
+        JOIN pg_catalog.pg_class ci ON ci.oid = i.indexrelid
+        JOIN pg_catalog.pg_class ct ON ct.oid = i.indrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND ct.relname = 'statement_last_state'
+          AND i.indisprimary = TRUE
+          AND i.indnatts = 4
+    ),
+    'statement_last_state primary key must have exactly 4 columns'
+);
+
+-- ===========================================================================
+-- T8: HOT contract — no index on statement_last_state covers calls or sample_ts
+-- ===========================================================================
+SELECT ok(
+    NOT EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_index i
+        JOIN pg_catalog.pg_class ci ON ci.oid = i.indexrelid
+        JOIN pg_catalog.pg_class ct ON ct.oid = i.indrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
+        JOIN pg_catalog.pg_attribute a ON a.attrelid = ct.oid AND a.attnum = ANY(i.indkey)
+        WHERE n.nspname = 'pgfr_record'
+          AND ct.relname = 'statement_last_state'
+          AND a.attname IN ('calls', 'sample_ts')
+    ),
+    'HOT contract: no index on statement_last_state must cover calls or sample_ts'
+);
+
+-- ===========================================================================
+-- T9: statement_last_state has fillfactor=70 storage parameter
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_last_state'
+          AND c.reloptions::text LIKE '%fillfactor=70%'
+    ),
+    'statement_last_state must have fillfactor=70'
+);
+
+-- ===========================================================================
+-- T10: _ensure_partition_v2() is idempotent — calling twice returns same name
+-- ===========================================================================
+DO $$
+DECLARE
+    r1 TEXT;
+    r2 TEXT;
+BEGIN
+    r1 := pgfr_record._ensure_partition_v2(CURRENT_DATE);
+    r2 := pgfr_record._ensure_partition_v2(CURRENT_DATE);
+    IF r1 IS DISTINCT FROM r2 THEN
+        RAISE EXCEPTION '_ensure_partition_v2 not idempotent: % vs %', r1, r2;
+    END IF;
+END;
+$$;
+SELECT pass('_ensure_partition_v2() is idempotent (same partition returned on repeated calls)');
+
+-- ===========================================================================
+-- T11-T12: Sparse insert — rows skipped when calls unchanged
+--          Seed last_state with current PGSS, then run collector again;
+--          verify no new rows inserted for unchanged queries.
+-- ===========================================================================
+DO $$
+BEGIN
+    -- Ensure pg_stat_statements is available
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RAISE NOTICE 'pg_stat_statements not available — skipping sparse insert tests';
+    END IF;
+END;
+$$;
+
+DO $$
+DECLARE
+    v_count_before BIGINT;
+    v_count_after  BIGINT;
+    v_sample_ts    INT4;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RETURN;
+    END IF;
+
+    -- Fully rebuild last_state so it mirrors current PGSS exactly
+    PERFORM pgfr_record._rebuild_statement_last_state();
+
+    v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
+
+    SELECT COUNT(*) INTO v_count_before
+    FROM pgfr_record.statement_snapshots_v2
+    WHERE sample_ts >= v_sample_ts;
+
+    -- Run sparse collector; since calls haven't changed, nothing should be inserted
+    PERFORM pgfr_record._collect_statement_snapshot_sparse(0);
+
+    SELECT COUNT(*) INTO v_count_after
+    FROM pgfr_record.statement_snapshots_v2
+    WHERE sample_ts > v_sample_ts;
+
+    IF v_count_after <> 0 THEN
+        RAISE EXCEPTION 'Sparse insert: expected 0 new rows when calls unchanged, got %', v_count_after;
+    END IF;
+END;
+$$;
+SELECT pass('Sparse insert: 0 rows inserted when calls unchanged after rebuild');
+
+-- T12: After artificially bumping calls in last_state downward (simulating reset),
+--      collector should insert at least one row.
+DO $$
+DECLARE
+    v_count_before BIGINT;
+    v_count_after  BIGINT;
+    v_sample_ts    INT4;
+    v_queryid      BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RETURN;
+    END IF;
+
+    -- Get a queryid from last_state
+    SELECT queryid INTO v_queryid FROM pgfr_record.statement_last_state LIMIT 1;
+    IF v_queryid IS NULL THEN RETURN; END IF;
+
+    -- Artificially inflate calls in last_state to force insertion on next tick
+    UPDATE pgfr_record.statement_last_state
+    SET calls = calls + 999999
+    WHERE queryid = v_queryid;
+
+    v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
+
+    SELECT COUNT(*) INTO v_count_before
+    FROM pgfr_record.statement_snapshots_v2;
+
+    PERFORM pgfr_record._collect_statement_snapshot_sparse(0);
+
+    SELECT COUNT(*) INTO v_count_after
+    FROM pgfr_record.statement_snapshots_v2;
+
+    -- Restore last_state
+    PERFORM pgfr_record._rebuild_statement_last_state();
+
+    IF v_count_after <= v_count_before THEN
+        RAISE EXCEPTION 'Sparse insert: expected >=1 row when calls dropped, got 0 new rows';
+    END IF;
+END;
+$$;
+SELECT pass('Sparse insert: rows stored when calls dropped (reset detection)');
+
+-- ===========================================================================
+-- T13-T14: Crash recovery — TRUNCATE last_state → run collector →
+--          exactly one baseline per (queryid,dbid,userid,toplevel), no duplicates
+-- ===========================================================================
+DO $$
+DECLARE
+    v_duplicates BIGINT;
+    v_pgss_count BIGINT;
+    v_ls_count   BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RETURN;
+    END IF;
+
+    -- Simulate crash: empty the UNLOGGED side table
+    TRUNCATE pgfr_record.statement_last_state;
+
+    -- Run collector (should detect empty table and rebuild)
+    PERFORM pgfr_record._collect_statement_snapshot_sparse(0);
+
+    -- Verify: exactly one row per (queryid,dbid,userid,toplevel) in last_state
+    SELECT COUNT(*) INTO v_duplicates
+    FROM (
+        SELECT queryid, dbid, userid, toplevel, COUNT(*) AS cnt
+        FROM pgfr_record.statement_last_state
+        GROUP BY queryid, dbid, userid, toplevel
+        HAVING COUNT(*) > 1
+    ) dups;
+
+    IF v_duplicates > 0 THEN
+        RAISE EXCEPTION 'Crash recovery: % duplicate (queryid,dbid,userid,toplevel) entries in last_state', v_duplicates;
+    END IF;
+END;
+$$;
+SELECT pass('Crash recovery: exactly one baseline per (queryid,dbid,userid,toplevel) after TRUNCATE');
+
+-- T14: After crash recovery, last_state row count should not exceed PGSS count
+DO $$
+DECLARE
+    v_pgss_count BIGINT;
+    v_ls_count   BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RETURN;
+    END IF;
+
+    SELECT COUNT(*) INTO v_pgss_count FROM pg_stat_statements;
+    SELECT COUNT(*) INTO v_ls_count FROM pgfr_record.statement_last_state;
+
+    IF v_ls_count > v_pgss_count THEN
+        RAISE EXCEPTION 'Crash recovery: last_state has % rows > PGSS % rows (stale entries)', v_ls_count, v_pgss_count;
+    END IF;
+END;
+$$;
+SELECT pass('Crash recovery: statement_last_state row count <= pg_stat_statements count after rebuild');
+
+-- ===========================================================================
+-- T15: ON CONFLICT DO UPDATE used — run 10 ticks, verify n_dead_tup stays bounded
+--      HOT updates should prevent unbounded dead tuple accumulation
+-- ===========================================================================
+DO $$
+DECLARE
+    i             INT;
+    v_dead_before BIGINT;
+    v_dead_after  BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RETURN;
+    END IF;
+
+    -- Initial rebuild
+    PERFORM pgfr_record._rebuild_statement_last_state();
+
+    SELECT n_dead_tup INTO v_dead_before
+    FROM pg_stat_user_tables
+    WHERE schemaname = 'pgfr_record' AND relname = 'statement_last_state';
+
+    -- Simulate 10 ticks by incrementing calls each time (forces upsert on each tick)
+    FOR i IN 1..10 LOOP
+        -- Bump all calls by 1 to force upsert path
+        UPDATE pgfr_record.statement_last_state SET calls = calls + 1;
+        -- Run collector — should use ON CONFLICT DO UPDATE
+        PERFORM pgfr_record._collect_statement_snapshot_sparse(i::BIGINT);
+    END LOOP;
+
+    -- Force stats update
+    ANALYZE pgfr_record.statement_last_state;
+
+    SELECT COALESCE(n_dead_tup, 0) INTO v_dead_after
+    FROM pg_stat_user_tables
+    WHERE schemaname = 'pgfr_record' AND relname = 'statement_last_state';
+
+    -- With HOT updates and fillfactor=70, dead tuples should stay well under 100
+    -- (autovacuum threshold is 1% = ~50 rows for a 5000-row table)
+    IF v_dead_after >= 100 THEN
+        RAISE WARNING 'ON CONFLICT DO UPDATE test: % dead tuples after 10 ticks (may indicate non-HOT updates)', v_dead_after;
+        -- Note: this is a WARNING not EXCEPTION because autovacuum timing affects this
+    END IF;
+END;
+$$;
+SELECT pass('ON CONFLICT DO UPDATE: 10 ticks completed without constraint violations');
+
+-- ===========================================================================
+-- T16: toplevel — two PGSS entries differing only in toplevel tracked independently
+-- ===========================================================================
+DO $$
+DECLARE
+    v_fake_queryid BIGINT := -9999999999;
+    v_dbid         OID;
+    v_userid       OID;
+    v_count_true   INT;
+    v_count_false  INT;
+BEGIN
+    SELECT oid INTO v_dbid FROM pg_database WHERE datname = current_database();
+    SELECT oid INTO v_userid FROM pg_roles WHERE rolname = current_user;
+
+    -- Insert two fake entries differing only in toplevel
+    INSERT INTO pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
+    VALUES
+        (v_fake_queryid, v_dbid, v_userid, TRUE,  100, 1),
+        (v_fake_queryid, v_dbid, v_userid, FALSE, 200, 1);
+
+    -- Verify both rows exist independently
+    SELECT COUNT(*) INTO v_count_true
+    FROM pgfr_record.statement_last_state
+    WHERE queryid = v_fake_queryid AND toplevel = TRUE;
+
+    SELECT COUNT(*) INTO v_count_false
+    FROM pgfr_record.statement_last_state
+    WHERE queryid = v_fake_queryid AND toplevel = FALSE;
+
+    -- Cleanup
+    DELETE FROM pgfr_record.statement_last_state WHERE queryid = v_fake_queryid;
+
+    IF v_count_true <> 1 OR v_count_false <> 1 THEN
+        RAISE EXCEPTION 'toplevel test: expected 1 row each for toplevel=TRUE and FALSE, got % and %',
+            v_count_true, v_count_false;
+    END IF;
+END;
+$$;
+SELECT pass('toplevel: two entries differing only in toplevel tracked independently in statement_last_state');
+
+-- ===========================================================================
+-- T17: _rebuild_statement_last_state() calls ANALYZE immediately after INSERT
+--      Verify stats exist post-rebuild (pg_stat_user_tables.last_analyze IS NOT NULL
+--      or n_live_tup reflects actual row count)
+-- ===========================================================================
+DO $$
+DECLARE
+    v_live_before BIGINT;
+    v_live_after  BIGINT;
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        RETURN;
+    END IF;
+
+    PERFORM pgfr_record._rebuild_statement_last_state();
+
+    -- ANALYZE must have updated pg_stat_user_tables n_live_tup
+    SELECT n_live_tup INTO v_live_after
+    FROM pg_stat_user_tables
+    WHERE schemaname = 'pgfr_record' AND relname = 'statement_last_state';
+
+    IF v_live_after IS NULL THEN
+        RAISE EXCEPTION '_rebuild_statement_last_state: n_live_tup IS NULL after ANALYZE';
+    END IF;
+END;
+$$;
+SELECT pass('_rebuild_statement_last_state: ANALYZE updates pg_stat_user_tables.n_live_tup');
+
+-- ===========================================================================
+-- T18: _ensure_partition_v2 creates partition for a future date
+-- ===========================================================================
+DO $$
+DECLARE
+    v_future_date DATE := CURRENT_DATE + 7;
+    v_part_name   TEXT;
+BEGIN
+    v_part_name := pgfr_record._ensure_partition_v2(v_future_date);
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record' AND c.relname = v_part_name
+    ) THEN
+        RAISE EXCEPTION '_ensure_partition_v2: partition % not found after creation', v_part_name;
+    END IF;
+
+    -- Cleanup test partition
+    EXECUTE format('DROP TABLE IF EXISTS pgfr_record.%I', v_part_name);
+END;
+$$;
+SELECT pass('_ensure_partition_v2: creates partition for future date and returns correct name');
+
+-- ===========================================================================
+-- T19: statement_snapshots_v2 partition has B-tree index on (queryid,dbid,userid,sample_ts DESC)
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class ci
+        JOIN pg_catalog.pg_class ct ON ct.oid = (
+            SELECT i.indrelid FROM pg_catalog.pg_index i WHERE i.indexrelid = ci.oid
+        )
+        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND ct.relname LIKE 'statement_snapshots_v2_%'
+          AND ci.relam = (SELECT oid FROM pg_am WHERE amname = 'btree')
+    ),
+    'statement_snapshots_v2 partitions must have a B-tree index'
+);
+
+-- ===========================================================================
+-- T20: statement_snapshots_v2 partition has BRIN index on sample_ts
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1
+        FROM pg_catalog.pg_class ci
+        JOIN pg_catalog.pg_index ix ON ix.indexrelid = ci.oid
+        JOIN pg_catalog.pg_class ct ON ct.oid = ix.indrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
+        JOIN pg_catalog.pg_attribute a ON a.attrelid = ct.oid AND a.attnum = ix.indkey[0]
+        WHERE n.nspname = 'pgfr_record'
+          AND ct.relname LIKE 'statement_snapshots_v2_%'
+          AND ci.relam = (SELECT oid FROM pg_am WHERE amname = 'brin')
+          AND a.attname = 'sample_ts'
+    ),
+    'statement_snapshots_v2 partitions must have a BRIN index on sample_ts'
+);
+
+-- ===========================================================================
+-- T21: pgss_dealloc_warning column exists in statement_snapshots_v2
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_attribute a
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2'
+          AND a.attname = 'pgss_dealloc_warning'
+          AND a.atttypid = pg_catalog.regtype('boolean')::oid
+    ),
+    'statement_snapshots_v2 must have pgss_dealloc_warning boolean column'
+);
+
+-- ===========================================================================
+-- T22: config keys for sparse collector observability exist
+-- ===========================================================================
+SELECT ok(
+    EXISTS (SELECT 1 FROM pgfr_record.config WHERE key = 'pgss_last_dealloc'),
+    'config key pgss_last_dealloc must exist'
+);
+
+SELECT ok(
+    EXISTS (SELECT 1 FROM pgfr_record.config WHERE key = 'pgss_rebuild_skip_count'),
+    'config key pgss_rebuild_skip_count must exist'
+);
+
+-- ===========================================================================
+-- T24: _collect_statement_snapshot_sparse handles pg_stat_statements unavailable
+--      gracefully (should not raise exception to caller)
+-- ===========================================================================
+DO $$
+DECLARE
+    v_ok BOOLEAN := TRUE;
+BEGIN
+    -- If pg_stat_statements IS available, this test verifies the function runs cleanly
+    -- If not available, the EXCEPTION block should catch it silently
+    BEGIN
+        PERFORM pgfr_record._collect_statement_snapshot_sparse(-999);
+    EXCEPTION WHEN OTHERS THEN
+        v_ok := FALSE;
+        RAISE WARNING 'Unexpected exception from _collect_statement_snapshot_sparse: %', SQLERRM;
+    END;
+
+    IF NOT v_ok THEN
+        RAISE EXCEPTION 'PGSS sparse collector must not propagate exceptions to caller';
+    END IF;
+END;
+$$;
+SELECT pass('_collect_statement_snapshot_sparse: does not propagate exceptions to caller');
+
+-- ===========================================================================
+-- T25: statement_snapshots_v2 sample_ts column is INT4
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_attribute a
+        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots_v2'
+          AND a.attname = 'sample_ts'
+          AND a.atttypid = pg_catalog.regtype('integer')::oid  -- int4
+          AND a.attnotnull = TRUE
+    ),
+    'statement_snapshots_v2.sample_ts must be INT4 NOT NULL'
+);
+
+-- ===========================================================================
+-- T26: Old statement_snapshots table untouched (dual-write constraint)
+-- ===========================================================================
+SELECT ok(
+    EXISTS (
+        SELECT 1 FROM pg_catalog.pg_class c
+        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'pgfr_record'
+          AND c.relname = 'statement_snapshots'
+          AND c.relkind = 'r'
+    ),
+    'Old statement_snapshots table must still exist (dual-write approach)'
+);
+
+-- Cleanup: rebuild last_state to a clean state after tests
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
+        PERFORM pgfr_record._rebuild_statement_last_state();
+    END IF;
+END;
+$$;
+
+SELECT * FROM finish();
+ROLLBACK;

--- a/_record/tests/test_sparse_collector.sql
+++ b/_record/tests/test_sparse_collector.sql
@@ -5,6 +5,10 @@
 -- Requires: pgTAP, pg_stat_statements
 -- PG14+ minimum
 --
+-- NOTE: T1 (epoch function exists) and T2 (epoch returns plausible value) were
+-- removed from this file after being moved to PR #5 (phase1-issue1-infra).
+-- This file starts at T3.
+--
 -- DEPENDENCY: This test file requires that the Phase 1 partition infrastructure
 -- (PR #5 / phase1-issue1-infra) is already installed, specifically:
 --   - pgfr_record.epoch()
@@ -13,60 +17,60 @@
 -- or merge PR #5 before running these tests.
 -- =============================================================================
 
-BEGIN;
+begin;
 
-SELECT plan(24);
+select plan(26);
 
 -- ---------------------------------------------------------------------------
 -- Helper: ensure a clean test partition exists
 -- ---------------------------------------------------------------------------
-DO $$
-BEGIN
+do $$
+begin
     -- Create a test partition for today if needed
     -- Requires _ensure_partition() from phase1-issue1-infra (PR #5)
-    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
-END;
+    perform pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+end;
 $$;
 
 -- ===========================================================================
 -- T3: statement_snapshots_v2 table exists and is partitioned
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2'
-          AND c.relkind = 'p'  -- partitioned table
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2'
+          and c.relkind = 'p'  -- partitioned table
     ),
     'statement_snapshots_v2 must exist as a partitioned table'
 );
 
 -- T4: statement_snapshots_v2 has toplevel boolean column
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_attribute a
-        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2'
-          AND a.attname = 'toplevel'
-          AND a.atttypid = pg_catalog.regtype('boolean')::oid
-          AND a.attnotnull = TRUE
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_attribute a
+        join pg_catalog.pg_class c on c.oid = a.attrelid
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2'
+          and a.attname = 'toplevel'
+          and a.atttypid = pg_catalog.regtype('boolean')::oid
+          and a.attnotnull = TRUE
     ),
     'statement_snapshots_v2 must have toplevel boolean not null'
 );
 
 -- T5: statement_snapshots_v2 has snapshot_id as BIGINT
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_attribute a
-        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2'
-          AND a.attname = 'snapshot_id'
-          AND a.atttypid = pg_catalog.regtype('bigint')::oid
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_attribute a
+        join pg_catalog.pg_class c on c.oid = a.attrelid
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2'
+          and a.attname = 'snapshot_id'
+          and a.atttypid = pg_catalog.regtype('bigint')::oid
     ),
     'statement_snapshots_v2.snapshot_id must be BIGINT'
 );
@@ -74,29 +78,29 @@ SELECT ok(
 -- ===========================================================================
 -- T6: statement_last_state table exists and is UNLOGGED
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_last_state'
-          AND c.relpersistence = 'u'  -- unlogged
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_last_state'
+          and c.relpersistence = 'u'  -- unlogged
     ),
     'statement_last_state must exist and be UNLOGGED'
 );
 
 -- T7: statement_last_state primary key covers (queryid, dbid, userid, toplevel)
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_index i
-        JOIN pg_catalog.pg_class ci ON ci.oid = i.indexrelid
-        JOIN pg_catalog.pg_class ct ON ct.oid = i.indrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND ct.relname = 'statement_last_state'
-          AND i.indisprimary = TRUE
-          AND i.indnatts = 4
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_index i
+        join pg_catalog.pg_class ci on ci.oid = i.indexrelid
+        join pg_catalog.pg_class ct on ct.oid = i.indrelid
+        join pg_catalog.pg_namespace n on n.oid = ct.relnamespace
+        where n.nspname = 'pgfr_record'
+          and ct.relname = 'statement_last_state'
+          and i.indisprimary = TRUE
+          and i.indnatts = 4
     ),
     'statement_last_state primary key must have exactly 4 columns'
 );
@@ -104,17 +108,17 @@ SELECT ok(
 -- ===========================================================================
 -- T8: HOT contract — no index on statement_last_state covers calls or sample_ts
 -- ===========================================================================
-SELECT ok(
-    NOT EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_index i
-        JOIN pg_catalog.pg_class ci ON ci.oid = i.indexrelid
-        JOIN pg_catalog.pg_class ct ON ct.oid = i.indrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
-        JOIN pg_catalog.pg_attribute a ON a.attrelid = ct.oid AND a.attnum = ANY(i.indkey)
-        WHERE n.nspname = 'pgfr_record'
-          AND ct.relname = 'statement_last_state'
-          AND a.attname IN ('calls', 'sample_ts')
+select ok(
+    not exists (
+        select 1
+        from pg_catalog.pg_index i
+        join pg_catalog.pg_class ci on ci.oid = i.indexrelid
+        join pg_catalog.pg_class ct on ct.oid = i.indrelid
+        join pg_catalog.pg_namespace n on n.oid = ct.relnamespace
+        join pg_catalog.pg_attribute a on a.attrelid = ct.oid and a.attnum = any(i.indkey)
+        where n.nspname = 'pgfr_record'
+          and ct.relname = 'statement_last_state'
+          and a.attname in ('calls', 'sample_ts')
     ),
     'HOT contract: no index on statement_last_state must cover calls or sample_ts'
 );
@@ -122,14 +126,14 @@ SELECT ok(
 -- ===========================================================================
 -- T9: statement_last_state has fillfactor=70 storage parameter
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_last_state'
-          AND c.reloptions::text LIKE '%fillfactor=70%'
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_last_state'
+          and c.reloptions::text like '%fillfactor=70%'
     ),
     'statement_last_state must have fillfactor=70'
 );
@@ -138,326 +142,364 @@ SELECT ok(
 -- T10: _ensure_partition('statement_snapshots_v2', ...) is idempotent —
 --      calling twice leaves exactly one partition for today
 -- ===========================================================================
-DO $$
-DECLARE
-    v_partition_name TEXT;
+do $$
+declare
+    v_partition_name text;
     v_count          INT;
-BEGIN
+begin
     v_partition_name := 'statement_snapshots_v2_' || to_char(CURRENT_DATE, 'YYYY_MM_DD');
     -- Call twice — must not raise and must leave exactly one partition
-    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
-    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
-    SELECT COUNT(*) INTO v_count
-    FROM pg_catalog.pg_class c
-    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-    WHERE n.nspname = 'pgfr_record' AND c.relname = v_partition_name;
-    IF v_count <> 1 THEN
-        RAISE EXCEPTION '_ensure_partition not idempotent: found % partition(s) for %', v_count, v_partition_name;
-    END IF;
-END;
+    perform pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+    perform pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+    select COUNT(*) into v_count
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'pgfr_record' and c.relname = v_partition_name;
+    if v_count <> 1 then
+        raise exception '_ensure_partition not idempotent: found % partition(s) for %', v_count, v_partition_name;
+    end if;
+end;
 $$;
-SELECT pass('_ensure_partition(''statement_snapshots_v2'', ...) is idempotent (partition exists after repeated calls)');
+select pass('_ensure_partition(''statement_snapshots_v2'', ...) is idempotent (partition exists after repeated calls)');
 
 -- ===========================================================================
 -- T11-T12: Sparse insert — rows skipped when calls unchanged
 --          Seed last_state with current PGSS, then run collector again;
 --          verify no new rows inserted for unchanged queries.
 -- ===========================================================================
-DO $$
-BEGIN
+do $$
+begin
     -- Ensure pg_stat_statements is available
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RAISE NOTICE 'pg_stat_statements not available — skipping sparse insert tests';
-    END IF;
-END;
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        raise notice 'pg_stat_statements not available — skipping sparse insert tests';
+    end if;
+end;
 $$;
 
-DO $$
-DECLARE
-    v_count_before BIGINT;
-    v_count_after  BIGINT;
+do $$
+declare
+    v_count_before bigint;
+    v_count_after  bigint;
     v_sample_ts    INT4;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RETURN;
-    END IF;
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
 
     -- Fully rebuild last_state so it mirrors current PGSS exactly
-    PERFORM pgfr_record._rebuild_statement_last_state();
+    perform pgfr_record._rebuild_statement_last_state();
 
-    v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
+    v_sample_ts := extract(EPOCH from now() - pgfr_record.epoch())::INT4;
 
-    SELECT COUNT(*) INTO v_count_before
-    FROM pgfr_record.statement_snapshots_v2
-    WHERE sample_ts >= v_sample_ts;
+    select COUNT(*) into v_count_before
+    from pgfr_record.statement_snapshots_v2
+    where sample_ts >= v_sample_ts;
 
     -- Run sparse collector; since calls haven't changed, nothing should be inserted
-    PERFORM pgfr_record._collect_statement_snapshot_sparse(0);
+    perform pgfr_record._collect_statement_snapshot_sparse(0);
 
-    SELECT COUNT(*) INTO v_count_after
-    FROM pgfr_record.statement_snapshots_v2
-    WHERE sample_ts > v_sample_ts;
+    select COUNT(*) into v_count_after
+    from pgfr_record.statement_snapshots_v2
+    where sample_ts > v_sample_ts;
 
-    IF v_count_after <> 0 THEN
-        RAISE EXCEPTION 'Sparse insert: expected 0 new rows when calls unchanged, got %', v_count_after;
-    END IF;
-END;
+    if v_count_after <> 0 then
+        raise exception 'Sparse insert: expected 0 new rows when calls unchanged, got %', v_count_after;
+    end if;
+end;
 $$;
-SELECT pass('Sparse insert: 0 rows inserted when calls unchanged after rebuild');
+select pass('Sparse insert: 0 rows inserted when calls unchanged after rebuild');
 
 -- T12: After artificially bumping calls in last_state downward (simulating reset),
 --      collector should insert at least one row.
-DO $$
-DECLARE
-    v_count_before BIGINT;
-    v_count_after  BIGINT;
+do $$
+declare
+    v_count_before bigint;
+    v_count_after  bigint;
     v_sample_ts    INT4;
-    v_queryid      BIGINT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RETURN;
-    END IF;
+    v_queryid      bigint;
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
 
     -- Get a queryid from last_state
-    SELECT queryid INTO v_queryid FROM pgfr_record.statement_last_state LIMIT 1;
-    IF v_queryid IS NULL THEN RETURN; END IF;
+    select queryid into v_queryid from pgfr_record.statement_last_state limit 1;
+    if v_queryid is null then return; end if;
 
     -- Artificially inflate calls in last_state to force insertion on next tick
-    UPDATE pgfr_record.statement_last_state
-    SET calls = calls + 999999
-    WHERE queryid = v_queryid;
+    update pgfr_record.statement_last_state
+    set calls = calls + 999999
+    where queryid = v_queryid;
 
-    v_sample_ts := EXTRACT(EPOCH FROM now() - pgfr_record.epoch())::INT4;
+    v_sample_ts := extract(EPOCH from now() - pgfr_record.epoch())::INT4;
 
-    SELECT COUNT(*) INTO v_count_before
-    FROM pgfr_record.statement_snapshots_v2;
+    select COUNT(*) into v_count_before
+    from pgfr_record.statement_snapshots_v2;
 
-    PERFORM pgfr_record._collect_statement_snapshot_sparse(0);
+    perform pgfr_record._collect_statement_snapshot_sparse(0);
 
-    SELECT COUNT(*) INTO v_count_after
-    FROM pgfr_record.statement_snapshots_v2;
+    select COUNT(*) into v_count_after
+    from pgfr_record.statement_snapshots_v2;
 
     -- Restore last_state
-    PERFORM pgfr_record._rebuild_statement_last_state();
+    perform pgfr_record._rebuild_statement_last_state();
 
-    IF v_count_after <= v_count_before THEN
-        RAISE EXCEPTION 'Sparse insert: expected >=1 row when calls dropped, got 0 new rows';
-    END IF;
-END;
+    if v_count_after <= v_count_before then
+        raise exception 'Sparse insert: expected >=1 row when calls dropped, got 0 new rows';
+    end if;
+end;
 $$;
-SELECT pass('Sparse insert: rows stored when calls dropped (reset detection)');
+select pass('Sparse insert: rows stored when calls dropped (reset detection)');
 
 -- ===========================================================================
 -- T13-T14: Crash recovery — TRUNCATE last_state → run collector →
 --          exactly one baseline per (queryid,dbid,userid,toplevel), no duplicates
 -- ===========================================================================
-DO $$
-DECLARE
-    v_duplicates BIGINT;
-    v_pgss_count BIGINT;
-    v_ls_count   BIGINT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RETURN;
-    END IF;
+do $$
+declare
+    v_duplicates bigint;
+    v_pgss_count bigint;
+    v_ls_count   bigint;
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
 
     -- Simulate crash: empty the UNLOGGED side table
-    TRUNCATE pgfr_record.statement_last_state;
+    truncate pgfr_record.statement_last_state;
 
     -- Run collector (should detect empty table and rebuild)
-    PERFORM pgfr_record._collect_statement_snapshot_sparse(0);
+    perform pgfr_record._collect_statement_snapshot_sparse(0);
 
     -- Verify: exactly one row per (queryid,dbid,userid,toplevel) in last_state
-    SELECT COUNT(*) INTO v_duplicates
-    FROM (
-        SELECT queryid, dbid, userid, toplevel, COUNT(*) AS cnt
-        FROM pgfr_record.statement_last_state
-        GROUP BY queryid, dbid, userid, toplevel
-        HAVING COUNT(*) > 1
+    select COUNT(*) into v_duplicates
+    from (
+        select queryid, dbid, userid, toplevel, COUNT(*) as cnt
+        from pgfr_record.statement_last_state
+        group by queryid, dbid, userid, toplevel
+        having COUNT(*) > 1
     ) dups;
 
-    IF v_duplicates > 0 THEN
-        RAISE EXCEPTION 'Crash recovery: % duplicate (queryid,dbid,userid,toplevel) entries in last_state', v_duplicates;
-    END IF;
-END;
+    if v_duplicates > 0 then
+        raise exception 'Crash recovery: % duplicate (queryid,dbid,userid,toplevel) entries in last_state', v_duplicates;
+    end if;
+end;
 $$;
-SELECT pass('Crash recovery: exactly one baseline per (queryid,dbid,userid,toplevel) after TRUNCATE');
+select pass('Crash recovery: exactly one baseline per (queryid,dbid,userid,toplevel) after TRUNCATE');
 
 -- T14: After crash recovery, last_state row count should not exceed PGSS count
-DO $$
-DECLARE
-    v_pgss_count BIGINT;
-    v_ls_count   BIGINT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RETURN;
-    END IF;
+do $$
+declare
+    v_pgss_count bigint;
+    v_ls_count   bigint;
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
 
-    SELECT COUNT(*) INTO v_pgss_count FROM pg_stat_statements;
-    SELECT COUNT(*) INTO v_ls_count FROM pgfr_record.statement_last_state;
+    select COUNT(*) into v_pgss_count from pg_stat_statements;
+    select COUNT(*) into v_ls_count from pgfr_record.statement_last_state;
 
-    IF v_ls_count > v_pgss_count THEN
-        RAISE EXCEPTION 'Crash recovery: last_state has % rows > PGSS % rows (stale entries)', v_ls_count, v_pgss_count;
-    END IF;
-END;
+    if v_ls_count > v_pgss_count then
+        raise exception 'Crash recovery: last_state has % rows > PGSS % rows (stale entries)', v_ls_count, v_pgss_count;
+    end if;
+end;
 $$;
-SELECT pass('Crash recovery: statement_last_state row count <= pg_stat_statements count after rebuild');
+select pass('Crash recovery: statement_last_state row count <= pg_stat_statements count after rebuild');
+
+-- ===========================================================================
+-- T_desync: stats_reset desync path triggers rebuild
+-- Simulate: set last sample_ts to past (0 = epoch start) so that
+--   epoch() + 0 * interval '1 second' = epoch() (2026-01-01 or similar)
+-- which is older than any real pg_stat_statements_info.stats_reset,
+-- triggering the desync rebuild path in _collect_statement_snapshot_sparse.
+-- ===========================================================================
+do $$
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
+    perform pgfr_record._rebuild_statement_last_state();
+    -- set all sample_ts to 0 so epoch()+0 = epoch() < real stats_reset
+    update pgfr_record.statement_last_state set sample_ts = 0;
+end;
+$$;
+
+select ok(
+    (select count(*) from pgfr_record.statement_last_state) > 0,
+    'T_desync pre: last_state has rows before desync test'
+);
+
+-- run collector — stats_reset should be newer than epoch(), triggering rebuild
+do $$
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
+    perform pgfr_record._collect_statement_snapshot_sparse(0);
+end;
+$$;
+
+select ok(
+    (select count(*) from pgfr_record.statement_last_state) > 0,
+    'T_desync: after stats_reset desync, last_state should be rebuilt and populated'
+);
 
 -- ===========================================================================
 -- T15: ON CONFLICT DO UPDATE used — run 10 ticks, verify n_dead_tup stays bounded
 --      HOT updates should prevent unbounded dead tuple accumulation
 -- ===========================================================================
-DO $$
-DECLARE
+do $$
+declare
     i             INT;
-    v_dead_before BIGINT;
-    v_dead_after  BIGINT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RETURN;
-    END IF;
+    v_dead_before bigint;
+    v_dead_after  bigint;
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
 
     -- Initial rebuild
-    PERFORM pgfr_record._rebuild_statement_last_state();
+    perform pgfr_record._rebuild_statement_last_state();
 
-    SELECT n_dead_tup INTO v_dead_before
-    FROM pg_stat_user_tables
-    WHERE schemaname = 'pgfr_record' AND relname = 'statement_last_state';
+    select n_dead_tup into v_dead_before
+    from pg_stat_user_tables
+    where schemaname = 'pgfr_record' and relname = 'statement_last_state';
 
     -- Simulate 10 ticks by incrementing calls each time (forces upsert on each tick)
-    FOR i IN 1..10 LOOP
+    for i in 1..10 loop
         -- Bump all calls by 1 to force upsert path
-        UPDATE pgfr_record.statement_last_state SET calls = calls + 1;
+        update pgfr_record.statement_last_state set calls = calls + 1;
         -- Run collector — should use ON CONFLICT DO UPDATE
-        PERFORM pgfr_record._collect_statement_snapshot_sparse(i::BIGINT);
-    END LOOP;
+        perform pgfr_record._collect_statement_snapshot_sparse(i::bigint);
+    end loop;
 
     -- Force stats update
-    ANALYZE pgfr_record.statement_last_state;
+    analyze pgfr_record.statement_last_state;
 
-    SELECT COALESCE(n_dead_tup, 0) INTO v_dead_after
-    FROM pg_stat_user_tables
-    WHERE schemaname = 'pgfr_record' AND relname = 'statement_last_state';
+    select coalesce(n_dead_tup, 0) into v_dead_after
+    from pg_stat_user_tables
+    where schemaname = 'pgfr_record' and relname = 'statement_last_state';
 
     -- With HOT updates and fillfactor=70, dead tuples should stay well under 100
     -- (autovacuum threshold is 1% = ~50 rows for a 5000-row table)
-    IF v_dead_after >= 100 THEN
-        RAISE WARNING 'ON CONFLICT DO UPDATE test: % dead tuples after 10 ticks (may indicate non-HOT updates)', v_dead_after;
+    if v_dead_after >= 100 then
+        raise warning 'ON CONFLICT DO UPDATE test: % dead tuples after 10 ticks (may indicate non-HOT updates)', v_dead_after;
         -- Note: this is a WARNING not EXCEPTION because autovacuum timing affects this
-    END IF;
-END;
+    end if;
+end;
 $$;
-SELECT pass('ON CONFLICT DO UPDATE: 10 ticks completed without constraint violations');
+select pass('ON CONFLICT DO UPDATE: 10 ticks completed without constraint violations');
 
 -- ===========================================================================
 -- T16: toplevel — two PGSS entries differing only in toplevel tracked independently
 -- ===========================================================================
-DO $$
-DECLARE
-    v_fake_queryid BIGINT := -9999999999;
-    v_dbid         OID;
-    v_userid       OID;
+do $$
+declare
+    v_fake_queryid bigint := -9999999999;
+    v_dbid         oid;
+    v_userid       oid;
     v_count_true   INT;
     v_count_false  INT;
-BEGIN
-    SELECT oid INTO v_dbid FROM pg_database WHERE datname = current_database();
-    SELECT oid INTO v_userid FROM pg_roles WHERE rolname = current_user;
+begin
+    select oid into v_dbid from pg_database where datname = current_database();
+    select oid into v_userid from pg_roles where rolname = current_user;
 
     -- Insert two fake entries differing only in toplevel
-    INSERT INTO pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
-    VALUES
+    insert into pgfr_record.statement_last_state (queryid, dbid, userid, toplevel, calls, sample_ts)
+    values
         (v_fake_queryid, v_dbid, v_userid, TRUE,  100, 1),
         (v_fake_queryid, v_dbid, v_userid, FALSE, 200, 1);
 
     -- Verify both rows exist independently
-    SELECT COUNT(*) INTO v_count_true
-    FROM pgfr_record.statement_last_state
-    WHERE queryid = v_fake_queryid AND toplevel = TRUE;
+    select COUNT(*) into v_count_true
+    from pgfr_record.statement_last_state
+    where queryid = v_fake_queryid and toplevel = TRUE;
 
-    SELECT COUNT(*) INTO v_count_false
-    FROM pgfr_record.statement_last_state
-    WHERE queryid = v_fake_queryid AND toplevel = FALSE;
+    select COUNT(*) into v_count_false
+    from pgfr_record.statement_last_state
+    where queryid = v_fake_queryid and toplevel = FALSE;
 
     -- Cleanup
-    DELETE FROM pgfr_record.statement_last_state WHERE queryid = v_fake_queryid;
+    delete from pgfr_record.statement_last_state where queryid = v_fake_queryid;
 
-    IF v_count_true <> 1 OR v_count_false <> 1 THEN
-        RAISE EXCEPTION 'toplevel test: expected 1 row each for toplevel=TRUE and FALSE, got % and %',
+    if v_count_true <> 1 or v_count_false <> 1 then
+        raise exception 'toplevel test: expected 1 row each for toplevel=TRUE and FALSE, got % and %',
             v_count_true, v_count_false;
-    END IF;
-END;
+    end if;
+end;
 $$;
-SELECT pass('toplevel: two entries differing only in toplevel tracked independently in statement_last_state');
+select pass('toplevel: two entries differing only in toplevel tracked independently in statement_last_state');
 
 -- ===========================================================================
 -- T17: _rebuild_statement_last_state() calls ANALYZE immediately after INSERT
 --      Verify stats exist post-rebuild (pg_stat_user_tables.last_analyze IS NOT NULL
 --      or n_live_tup reflects actual row count)
 -- ===========================================================================
-DO $$
-DECLARE
-    v_live_before BIGINT;
-    v_live_after  BIGINT;
-BEGIN
-    IF NOT EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        RETURN;
-    END IF;
+do $$
+declare
+    v_live_before bigint;
+    v_live_after  bigint;
+begin
+    if not exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        return;
+    end if;
 
-    PERFORM pgfr_record._rebuild_statement_last_state();
+    perform pgfr_record._rebuild_statement_last_state();
 
     -- ANALYZE must have updated pg_stat_user_tables n_live_tup
-    SELECT n_live_tup INTO v_live_after
-    FROM pg_stat_user_tables
-    WHERE schemaname = 'pgfr_record' AND relname = 'statement_last_state';
+    select n_live_tup into v_live_after
+    from pg_stat_user_tables
+    where schemaname = 'pgfr_record' and relname = 'statement_last_state';
 
-    IF v_live_after IS NULL THEN
-        RAISE EXCEPTION '_rebuild_statement_last_state: n_live_tup IS NULL after ANALYZE';
-    END IF;
-END;
+    if v_live_after is null then
+        raise exception '_rebuild_statement_last_state: n_live_tup IS NULL after ANALYZE';
+    end if;
+end;
 $$;
-SELECT pass('_rebuild_statement_last_state: ANALYZE updates pg_stat_user_tables.n_live_tup');
+select pass('_rebuild_statement_last_state: ANALYZE updates pg_stat_user_tables.n_live_tup');
 
 -- ===========================================================================
 -- T18: _ensure_partition('statement_snapshots_v2', ...) creates partition for a future date
 -- ===========================================================================
-DO $$
-DECLARE
+do $$
+declare
     v_future_date DATE := CURRENT_DATE + 7;
-    v_part_name   TEXT;
-BEGIN
+    v_part_name   text;
+begin
     v_part_name := 'statement_snapshots_v2_' || to_char(v_future_date, 'YYYY_MM_DD');
 
-    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', v_future_date);
+    perform pgfr_record._ensure_partition('statement_snapshots_v2', v_future_date);
 
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record' AND c.relname = v_part_name
-    ) THEN
-        RAISE EXCEPTION '_ensure_partition: partition % not found after creation', v_part_name;
-    END IF;
+    if not exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record' and c.relname = v_part_name
+    ) then
+        raise exception '_ensure_partition: partition % not found after creation', v_part_name;
+    end if;
 
     -- Cleanup test partition
-    EXECUTE format('DROP TABLE IF EXISTS pgfr_record.%I', v_part_name);
-END;
+    execute format('DROP TABLE IF EXISTS pgfr_record.%I', v_part_name);
+end;
 $$;
-SELECT pass('_ensure_partition(''statement_snapshots_v2'', ...): creates partition for future date');
+select pass('_ensure_partition(''statement_snapshots_v2'', ...): creates partition for future date');
 
 -- ===========================================================================
 -- T19: statement_snapshots_v2 partition has B-tree index
 --      (_btree_idx suffix from _ensure_partition in PR #5)
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class ci
-        JOIN pg_catalog.pg_index ix ON ix.indexrelid = ci.oid
-        JOIN pg_catalog.pg_class ct ON ct.oid = ix.indrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND ct.relname LIKE 'statement_snapshots_v2_%'
-          AND ci.relname LIKE '%_btree_idx'
-          AND ci.relam = (SELECT oid FROM pg_am WHERE amname = 'btree')
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_class ci
+        join pg_catalog.pg_index ix on ix.indexrelid = ci.oid
+        join pg_catalog.pg_class ct on ct.oid = ix.indrelid
+        join pg_catalog.pg_namespace n on n.oid = ct.relnamespace
+        where n.nspname = 'pgfr_record'
+          and ct.relname like 'statement_snapshots_v2_%'
+          and ci.relname like '%_btree_idx'
+          and ci.relam = (select oid from pg_am where amname = 'btree')
     ),
     'statement_snapshots_v2 partitions must have a B-tree index (_btree_idx)'
 );
@@ -466,19 +508,19 @@ SELECT ok(
 -- T20: statement_snapshots_v2 partition has BRIN index on sample_ts
 --      (_brin_idx suffix from _ensure_partition in PR #5)
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1
-        FROM pg_catalog.pg_class ci
-        JOIN pg_catalog.pg_index ix ON ix.indexrelid = ci.oid
-        JOIN pg_catalog.pg_class ct ON ct.oid = ix.indrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
-        JOIN pg_catalog.pg_attribute a ON a.attrelid = ct.oid AND a.attnum = ix.indkey[0]
-        WHERE n.nspname = 'pgfr_record'
-          AND ct.relname LIKE 'statement_snapshots_v2_%'
-          AND ci.relname LIKE '%_brin_idx'
-          AND ci.relam = (SELECT oid FROM pg_am WHERE amname = 'brin')
-          AND a.attname = 'sample_ts'
+select ok(
+    exists (
+        select 1
+        from pg_catalog.pg_class ci
+        join pg_catalog.pg_index ix on ix.indexrelid = ci.oid
+        join pg_catalog.pg_class ct on ct.oid = ix.indrelid
+        join pg_catalog.pg_namespace n on n.oid = ct.relnamespace
+        join pg_catalog.pg_attribute a on a.attrelid = ct.oid and a.attnum = ix.indkey[0]
+        where n.nspname = 'pgfr_record'
+          and ct.relname like 'statement_snapshots_v2_%'
+          and ci.relname like '%_brin_idx'
+          and ci.relam = (select oid from pg_am where amname = 'brin')
+          and a.attname = 'sample_ts'
     ),
     'statement_snapshots_v2 partitions must have a BRIN index on sample_ts (_brin_idx)'
 );
@@ -486,15 +528,15 @@ SELECT ok(
 -- ===========================================================================
 -- T21: pgss_dealloc_warning column exists in statement_snapshots_v2
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_attribute a
-        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2'
-          AND a.attname = 'pgss_dealloc_warning'
-          AND a.atttypid = pg_catalog.regtype('boolean')::oid
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_attribute a
+        join pg_catalog.pg_class c on c.oid = a.attrelid
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2'
+          and a.attname = 'pgss_dealloc_warning'
+          and a.atttypid = pg_catalog.regtype('boolean')::oid
     ),
     'statement_snapshots_v2 must have pgss_dealloc_warning boolean column'
 );
@@ -502,13 +544,13 @@ SELECT ok(
 -- ===========================================================================
 -- T22: config keys for sparse collector observability exist
 -- ===========================================================================
-SELECT ok(
-    EXISTS (SELECT 1 FROM pgfr_record.config WHERE key = 'pgss_last_dealloc'),
+select ok(
+    exists (select 1 from pgfr_record.config where key = 'pgss_last_dealloc'),
     'config key pgss_last_dealloc must exist'
 );
 
-SELECT ok(
-    EXISTS (SELECT 1 FROM pgfr_record.config WHERE key = 'pgss_rebuild_skip_count'),
+select ok(
+    exists (select 1 from pgfr_record.config where key = 'pgss_rebuild_skip_count'),
     'config key pgss_rebuild_skip_count must exist'
 );
 
@@ -516,39 +558,39 @@ SELECT ok(
 -- T24: _collect_statement_snapshot_sparse handles pg_stat_statements unavailable
 --      gracefully (should not raise exception to caller)
 -- ===========================================================================
-DO $$
-DECLARE
-    v_ok BOOLEAN := TRUE;
-BEGIN
+do $$
+declare
+    v_ok boolean := TRUE;
+begin
     -- If pg_stat_statements IS available, this test verifies the function runs cleanly
     -- If not available, the EXCEPTION block should catch it silently
-    BEGIN
-        PERFORM pgfr_record._collect_statement_snapshot_sparse(-999);
-    EXCEPTION WHEN OTHERS THEN
+    begin
+        perform pgfr_record._collect_statement_snapshot_sparse(-999);
+    exception when others then
         v_ok := FALSE;
-        RAISE WARNING 'Unexpected exception from _collect_statement_snapshot_sparse: %', SQLERRM;
-    END;
+        raise warning 'Unexpected exception from _collect_statement_snapshot_sparse: %', SQLERRM;
+    end;
 
-    IF NOT v_ok THEN
-        RAISE EXCEPTION 'PGSS sparse collector must not propagate exceptions to caller';
-    END IF;
-END;
+    if not v_ok then
+        raise exception 'PGSS sparse collector must not propagate exceptions to caller';
+    end if;
+end;
 $$;
-SELECT pass('_collect_statement_snapshot_sparse: does not propagate exceptions to caller');
+select pass('_collect_statement_snapshot_sparse: does not propagate exceptions to caller');
 
 -- ===========================================================================
 -- T25: statement_snapshots_v2 sample_ts column is INT4
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_attribute a
-        JOIN pg_catalog.pg_class c ON c.oid = a.attrelid
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots_v2'
-          AND a.attname = 'sample_ts'
-          AND a.atttypid = pg_catalog.regtype('integer')::oid  -- int4
-          AND a.attnotnull = TRUE
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_attribute a
+        join pg_catalog.pg_class c on c.oid = a.attrelid
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots_v2'
+          and a.attname = 'sample_ts'
+          and a.atttypid = pg_catalog.regtype('integer')::oid  -- int4
+          and a.attnotnull = TRUE
     ),
     'statement_snapshots_v2.sample_ts must be INT4 NOT NULL'
 );
@@ -556,25 +598,25 @@ SELECT ok(
 -- ===========================================================================
 -- T26: Old statement_snapshots table untouched (dual-write constraint)
 -- ===========================================================================
-SELECT ok(
-    EXISTS (
-        SELECT 1 FROM pg_catalog.pg_class c
-        JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'pgfr_record'
-          AND c.relname = 'statement_snapshots'
-          AND c.relkind = 'r'
+select ok(
+    exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname = 'statement_snapshots'
+          and c.relkind = 'r'
     ),
     'Old statement_snapshots table must still exist (dual-write approach)'
 );
 
 -- Cleanup: rebuild last_state to a clean state after tests
-DO $$
-BEGIN
-    IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements') THEN
-        PERFORM pgfr_record._rebuild_statement_last_state();
-    END IF;
-END;
+do $$
+begin
+    if exists (select 1 from pg_extension where extname = 'pg_stat_statements') then
+        perform pgfr_record._rebuild_statement_last_state();
+    end if;
+end;
 $$;
 
-SELECT * FROM finish();
-ROLLBACK;
+select * from finish();
+rollback;

--- a/_record/tests/test_sparse_collector.sql
+++ b/_record/tests/test_sparse_collector.sql
@@ -8,7 +8,7 @@
 
 BEGIN;
 
-SELECT plan(26);
+SELECT plan(24);
 
 -- ---------------------------------------------------------------------------
 -- Helper: ensure a clean test partition exists
@@ -16,28 +16,9 @@ SELECT plan(26);
 DO $$
 BEGIN
     -- Create a test partition for today if needed
-    PERFORM pgfr_record._ensure_partition_v2(CURRENT_DATE);
+    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
 END;
 $$;
-
--- ===========================================================================
--- T1: epoch() function is IMMUTABLE and returns a timestamptz
--- ===========================================================================
-SELECT is(
-    pg_catalog.provolatile::text,
-    'i',
-    'epoch() must be IMMUTABLE'
-)
-FROM pg_catalog.pg_proc p
-JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
-WHERE n.nspname = 'pgfr_record' AND p.proname = 'epoch';
-
--- T2: epoch() returns 2026-01-01 UTC
-SELECT is(
-    pgfr_record.epoch(),
-    '2026-01-01 00:00:00+00'::timestamptz,
-    'epoch() must return 2026-01-01 00:00:00 UTC'
-);
 
 -- ===========================================================================
 -- T3: statement_snapshots_v2 table exists and is partitioned
@@ -146,21 +127,28 @@ SELECT ok(
 );
 
 -- ===========================================================================
--- T10: _ensure_partition_v2() is idempotent — calling twice returns same name
+-- T10: _ensure_partition('statement_snapshots_v2', ...) is idempotent —
+--      calling twice leaves exactly one partition for today
 -- ===========================================================================
 DO $$
 DECLARE
-    r1 TEXT;
-    r2 TEXT;
+    v_partition_name TEXT;
+    v_count          INT;
 BEGIN
-    r1 := pgfr_record._ensure_partition_v2(CURRENT_DATE);
-    r2 := pgfr_record._ensure_partition_v2(CURRENT_DATE);
-    IF r1 IS DISTINCT FROM r2 THEN
-        RAISE EXCEPTION '_ensure_partition_v2 not idempotent: % vs %', r1, r2;
+    v_partition_name := 'statement_snapshots_v2_' || to_char(CURRENT_DATE, 'YYYY_MM_DD');
+    -- Call twice — must not raise and must leave exactly one partition
+    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', CURRENT_DATE);
+    SELECT COUNT(*) INTO v_count
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'pgfr_record' AND c.relname = v_partition_name;
+    IF v_count <> 1 THEN
+        RAISE EXCEPTION '_ensure_partition not idempotent: found % partition(s) for %', v_count, v_partition_name;
     END IF;
 END;
 $$;
-SELECT pass('_ensure_partition_v2() is idempotent (same partition returned on repeated calls)');
+SELECT pass('_ensure_partition(''statement_snapshots_v2'', ...) is idempotent (partition exists after repeated calls)');
 
 -- ===========================================================================
 -- T11-T12: Sparse insert — rows skipped when calls unchanged
@@ -422,49 +410,53 @@ $$;
 SELECT pass('_rebuild_statement_last_state: ANALYZE updates pg_stat_user_tables.n_live_tup');
 
 -- ===========================================================================
--- T18: _ensure_partition_v2 creates partition for a future date
+-- T18: _ensure_partition('statement_snapshots_v2', ...) creates partition for a future date
 -- ===========================================================================
 DO $$
 DECLARE
     v_future_date DATE := CURRENT_DATE + 7;
     v_part_name   TEXT;
 BEGIN
-    v_part_name := pgfr_record._ensure_partition_v2(v_future_date);
+    v_part_name := 'statement_snapshots_v2_' || to_char(v_future_date, 'YYYY_MM_DD');
+
+    PERFORM pgfr_record._ensure_partition('statement_snapshots_v2', v_future_date);
 
     IF NOT EXISTS (
         SELECT 1 FROM pg_catalog.pg_class c
         JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
         WHERE n.nspname = 'pgfr_record' AND c.relname = v_part_name
     ) THEN
-        RAISE EXCEPTION '_ensure_partition_v2: partition % not found after creation', v_part_name;
+        RAISE EXCEPTION '_ensure_partition: partition % not found after creation', v_part_name;
     END IF;
 
     -- Cleanup test partition
     EXECUTE format('DROP TABLE IF EXISTS pgfr_record.%I', v_part_name);
 END;
 $$;
-SELECT pass('_ensure_partition_v2: creates partition for future date and returns correct name');
+SELECT pass('_ensure_partition(''statement_snapshots_v2'', ...): creates partition for future date');
 
 -- ===========================================================================
--- T19: statement_snapshots_v2 partition has B-tree index on (queryid,dbid,userid,sample_ts DESC)
+-- T19: statement_snapshots_v2 partition has B-tree index
+--      (_btree_idx suffix from _ensure_partition in PR #5)
 -- ===========================================================================
 SELECT ok(
     EXISTS (
         SELECT 1
         FROM pg_catalog.pg_class ci
-        JOIN pg_catalog.pg_class ct ON ct.oid = (
-            SELECT i.indrelid FROM pg_catalog.pg_index i WHERE i.indexrelid = ci.oid
-        )
+        JOIN pg_catalog.pg_index ix ON ix.indexrelid = ci.oid
+        JOIN pg_catalog.pg_class ct ON ct.oid = ix.indrelid
         JOIN pg_catalog.pg_namespace n ON n.oid = ct.relnamespace
         WHERE n.nspname = 'pgfr_record'
           AND ct.relname LIKE 'statement_snapshots_v2_%'
+          AND ci.relname LIKE '%_btree_idx'
           AND ci.relam = (SELECT oid FROM pg_am WHERE amname = 'btree')
     ),
-    'statement_snapshots_v2 partitions must have a B-tree index'
+    'statement_snapshots_v2 partitions must have a B-tree index (_btree_idx)'
 );
 
 -- ===========================================================================
 -- T20: statement_snapshots_v2 partition has BRIN index on sample_ts
+--      (_brin_idx suffix from _ensure_partition in PR #5)
 -- ===========================================================================
 SELECT ok(
     EXISTS (
@@ -476,10 +468,11 @@ SELECT ok(
         JOIN pg_catalog.pg_attribute a ON a.attrelid = ct.oid AND a.attnum = ix.indkey[0]
         WHERE n.nspname = 'pgfr_record'
           AND ct.relname LIKE 'statement_snapshots_v2_%'
+          AND ci.relname LIKE '%_brin_idx'
           AND ci.relam = (SELECT oid FROM pg_am WHERE amname = 'brin')
           AND a.attname = 'sample_ts'
     ),
-    'statement_snapshots_v2 partitions must have a BRIN index on sample_ts'
+    'statement_snapshots_v2 partitions must have a BRIN index on sample_ts (_brin_idx)'
 );
 
 -- ===========================================================================


### PR DESCRIPTION
Implements #3.

## Summary

- **`statement_snapshots_v2`** — partitioned table (`PARTITION BY RANGE (sample_ts int4)`, `BIGINT snapshot_id`, `toplevel boolean NOT NULL`)
- **`statement_last_state`** — UNLOGGED side table (HOT-optimized, `fillfactor=70`, no mutable column indexes)
- **`_rebuild_statement_last_state()`** — TRUNCATE + INSERT from `pg_stat_statements` + ANALYZE
- **`_collect_statement_snapshot_sparse()`** — sparse collector with:
  - Advisory lock (`pg_try_advisory_xact_lock(hashtext('pgfr_last_state_rebuild'))`)
  - Clean-restart desync detection (`stats_reset` > `max(sample_ts)`)
  - Crash recovery (UNLOGGED empty → rebuild)
  - Daily partition boundary (TRUNCATE+rebuild at day boundary)
  - `ON CONFLICT DO UPDATE` for HOT-eligible upserts (only `calls`, `sample_ts` change)
  - `pgss_dealloc_warning` flag (cluster-wide PGSS eviction, not per-db)
  - EXCEPTION block isolates PGSS failures from other collection sections
- **pgTAP tests** in `_record/tests/test_sparse_collector.sql` (26 assertions)

## Old table preserved

`statement_snapshots` is **not modified** — dual-write approach per SPEC Q2.

## Design decisions

- `epoch()` is fixed at `2026-01-01 00:00:00 UTC` (IMMUTABLE, changing it corrupts all stored timestamps)
- `pgss_dealloc_warning` is documented as cluster-wide signal to avoid per-db misinterpretation
- Advisory lock skips tick and increments `pgss_rebuild_skip_count` in `config` (observable)
- PG14+ minimum — relies on `pg_stat_statements_info.stats_reset` and `toplevel` column

Closes #3