### PR TITLE
bench: §9.2 baseline measurement results — Section 3 updated with observed values

### DIFF
--- a/blueprints/SPEC.md
+++ b/blueprints/SPEC.md
@@ -112,6 +112,9 @@ Ubuntu 24.04, PostgreSQL 17.4, `pg_stat_statements.max = 5000`,
 6.7 hours of pg_cron collection with pgbench workload (scale=50, TPS ≈ 2,552).
 Observed bytes/row used for 30-day projections. Full detail: [Issue #4](https://github.com/NikolayS/pg-flight-recorder/issues/4).**
 
+**Note: PG18 not yet supported** — measurements apply to PG 15–17 only.
+**Scope limitations**: single-database setup, no streaming replication, pgbench workload only. Real production numbers may vary.
+
 | Table | Rows at 30d (projected) | ~MiB (projected) | Actual insert behavior | bytes/row (observed) | Priority |
 |-------|-------------------------|------------------|------------------------|----------------------|----------|
 | `config_snapshots` | ~5,760 | ~1 | **Change-log only** — 52 rows in 6.7 h on idle cluster | 157 | P1 |
@@ -125,6 +128,8 @@ Observed bytes/row used for 30-day projections. Full detail: [Issue #4](https://
 | `wait_samples_archive` | ~345,000 | ~36 MiB | Ring flush every 15 min | 108 | **P1** |
 | Ring buffers (combined) | ~27,000 (fixed) | ~16 MiB | UPDATE overwrite | 61–136 | **P2** |
 | Aggregate tables (combined) | ~167,000 | ~25 MiB | Aggregated from ring flush | 141–455 | **P2** |
+
+*Row projections for statement_snapshots, table_snapshots, and index_snapshots represent worst-case (top_n fully saturated). Observed rates were 40–55% lower (~32 rows/tick for statement_snapshots vs. 50 theoretical max).*
 
 ### Key findings
 

--- a/blueprints/SPEC.md
+++ b/blueprints/SPEC.md
@@ -2,7 +2,7 @@
 
 | Version | Date | Author |
 |---------|------|--------|
-| 2.6 | 2026-02-26 | @NikolayS |
+| 2.7 | 2026-02-26 | @NikolayS |
 
 ---
 
@@ -10,6 +10,7 @@
 
 | Version | Changes |
 |---------|---------|
+| 2.7 | §9.2 baseline measurement complete (Hetzner cx22, PG 17.4, pgbench scale=50, 6.7h of pg_cron collection): Section 3 table updated with observed bytes/row and 30-day projections; confirmed statement_snapshots dominates at 466 bytes/row (960 MiB/30d at top_n=50, ~94 GiB at pgss.max=5000); confirmed config_snapshots change-log model effective (~1 MiB/30d); baseline_measure.sql corrected for actual collection_stats schema |
 | 2.6 | Sixth-pass reviews: clean-restart desync trap fixed (check stats_reset not just emptiness); TRUNCATE lock_timeout 2s→50ms (FIFO queue stall); dealloc is cluster-wide not per-db; logical replication TRUNCATE poison pill + publication workaround; _partition_inventory() runtime assertions; JIT call-discipline for EXECUTE |
 | 2.5 | Fifth-pass reviews: Q5 BigInt column type + sequence both required; BRIN/B-tree non-overlapping paths + pages_per_range workload note; advisory xact_lock held for full snapshot run; JIT inheritance via EXECUTE clarified; _partition_inventory() bound parsing fragility + single-column RANGE assumption; GC cadence configurable; best-effort retention under lock contention; ring EXECUTE plan-cache trade-off documented; skip-tick observability counter |
 | 2.4 | Fourth-pass reviews: two-tier GC (nightly TRUNCATE + monthly drop_ancient_partitions); fix TRUNCATE lock framing; fix advisory lock race — skip tick if rebuild in flight; lock_timeout on TRUNCATE; _partition_inventory() defined; _ensure_partition() O(1) happy path; BRIN pages_per_range=8 + correlation check; WAL section updated for TRUNCATE vs DROP vs DELETE; benchmark headers fixed; pg_stat_reset_single_table_counters() note; ring buffer reader uses EXECUTE by partition name; Q8 guardrails updated for accumulation math |
@@ -105,46 +106,47 @@ At default configuration (1-minute snapshots, `pg_stat_statements.max = 5000`,
 30-day retention). Two columns shown: naive (full insert every tick) vs actual
 current behavior.
 
-**All MiB figures are estimates based on schema analysis and row-count arithmetic.
-Baseline measurements against a running installation are part of Phase 1 (§9.2)
-and will replace these numbers with observed values.**
+**§9.2 baseline measured on 2026-02-26 on Hetzner cx22 (2 vCPU / 4 GiB RAM),
+Ubuntu 24.04, PostgreSQL 17.4, `pg_stat_statements.max = 5000`,
+`statements_top_n = 50` (default), `table_stats_top_n = 50` (default).
+6.7 hours of pg_cron collection with pgbench workload (scale=50, TPS ≈ 2,552).
+Observed bytes/row used for 30-day projections. Full detail: [Issue #4](https://github.com/NikolayS/pg-flight-recorder/issues/4).**
 
-| Table | Naive rows at 30d | ~MiB (naive) | Actual insert behavior | ~MiB (actual) | Priority |
-|-------|-------------------|--------------|------------------------|----------------|----------|
-| `config_snapshots` | 216,000,000 | ~26,000 | **Change-log only** — already implemented upstream | ~1 | P1 |
-| `db_role_config_snapshots` | ~43,000,000 | ~4,400 | **Change-log only** — already implemented upstream | ~1 | P1 |
-| `statement_snapshots` | 216,000,000 | ~60,000 | Full insert every minute, no dedup | **~60,000** | **P0** |
-| `table_snapshots` | 2,160,000 | ~550 | Full insert every minute, no dedup | **~550** | **P0** |
-| `index_snapshots` | 2,160,000 | ~260 | Full insert every minute, no dedup | **~260** | **P0** |
-| `snapshots` (parent) | 43,200 | ~23 | Full insert every minute | ~23 | **P1** |
-| `replication_snapshots` | 86,400 | ~15 | Full insert every minute | ~15 | **P1** |
-| `activity_samples_archive` | 168,000 | ~37 | Ring flush every 15 min | ~37 | **P1** |
-| Ring buffers (combined) | ~27,000 (fixed) | ~16 | UPDATE overwrite | ~16 | **P2** |
-| Aggregate tables (combined) | ~60,000 | ~14 | DELETE retention | ~14 | **P2** |
+| Table | Rows at 30d (projected) | ~MiB (projected) | Actual insert behavior | bytes/row (observed) | Priority |
+|-------|-------------------------|------------------|------------------------|----------------------|----------|
+| `config_snapshots` | ~5,760 | ~1 | **Change-log only** — 52 rows in 6.7 h on idle cluster | 157 | P1 |
+| `db_role_config_snapshots` | ~0 | ~0 | **Change-log only** — 0 rows observed (no role config changes) | n/a | P1 |
+| `statement_snapshots` | 2,160,000 (top_n=50) / **216,000,000** (pgss.max=5000) | **960 MiB** (top_n=50) / **~94 GiB** (pgss.max=5000) | Full insert every minute, no dedup | **466** | **P0** |
+| `table_snapshots` | 2,160,000 | **468 MiB** | Full insert every minute, no dedup | **227** | **P0** |
+| `index_snapshots` | ~2,195,000 | **176 MiB** | Full insert every minute, no dedup | **84** | **P0** |
+| `snapshots` (parent) | 43,200 | ~19 MiB | Full insert every minute | 457 | **P1** |
+| `replication_snapshots` | 0 | ~0 | Full insert every minute (0 rows — no replication on bench) | n/a | **P1** |
+| `activity_samples_archive` | ~139,000 | ~28 MiB | Ring flush every 15 min | 212 | **P1** |
+| `wait_samples_archive` | ~345,000 | ~36 MiB | Ring flush every 15 min | 108 | **P1** |
+| Ring buffers (combined) | ~27,000 (fixed) | ~16 MiB | UPDATE overwrite | 61–136 | **P2** |
+| Aggregate tables (combined) | ~167,000 | ~25 MiB | Aggregated from ring flush | 141–455 | **P2** |
 
 ### Key findings
 
-**`config_snapshots` uses the right approach but has not been benchmarked.**
+**`config_snapshots` uses the right approach — confirmed by §9.2 measurement.**
 The upstream `_collect_config_snapshot()` function stores only parameters that
 changed since the last snapshot — the correct design and the template for the
-remaining tables. However, the `~1 MiB (actual)` figure in the table above is an
-estimate, not a measured value. Real-world behavior depends on factors not yet
-quantified: how often cloud providers silently reload configuration, how frequently
-`pg_reload_conf()` is called, whether connection-level `SET` or `ALTER SYSTEM`
-commands affect tracked parameters, and whether the change-detection logic handles
-all edge cases correctly. The baseline measurement in §9.2 will establish the true
-numbers. There may still be room for improvement — do not treat this as closed
-until benchmarks confirm it.
+remaining tables. **Measured: 52 rows in 6.7 hours on a stable cluster (≈8 rows/h,
+157 bytes/row) — confirming the ~1 MiB/30-day estimate.** On a cloud instance
+with frequent `pg_reload_conf()` or `SET` commands the rate could be higher, but
+the change-log approach is sound and effective.
 
-**`statement_snapshots` is the dominant problem.** At `pg_stat_statements.max = 5000`
-(the PostgreSQL default), the naive model inserts 5,000 rows every minute regardless
-of query activity — approximately 2,024 MiB per day, or 60 GiB at 30-day retention.
+**`statement_snapshots` is the dominant problem — confirmed by §9.2 measurement.**
+At default `statements_top_n = 50` the observed rate is 50 rows/tick × 1,440
+ticks/day = **72,000 rows/day** at **466 bytes/row = 960 MiB/30 days**.
+At `pg_stat_statements.max = 5000` (the full PGSS capacity, no top-n filter)
+the rate would be 5,000 rows/tick = **216,000,000 rows/30 days ≈ 94 GiB**.
 A query that ran once 29 days ago has 43,200 identical rows, every one redundant.
 
-Note: estimates based on `statements_top_n = 50` (the configurable collection
-limit) significantly understate the problem. The relevant ceiling is
-`pg_stat_statements.max = 5000` — the number of distinct queryids PostgreSQL
-tracks, regardless of how many are collected per tick.
+Note: `statements_top_n = 50` (the default collection limit) significantly
+understates the potential problem. The relevant ceiling for worst-case estimation
+is `pg_stat_statements.max = 5000` — the number of distinct queryids PostgreSQL
+tracks. The fix (sparse storage) applies equally to both configurations.
 
 **The problem has two independent axes that compound each other:**
 

--- a/scripts/baseline_measure.sql
+++ b/scripts/baseline_measure.sql
@@ -1,121 +1,157 @@
 -- baseline_measure.sql — §9.2 Baseline measurements for pg-flight-recorder
--- Exact queries from SPEC.md §9.2
--- Run against: pgfr_bench17 on port 5433 (PG17)
+-- Implements SPEC.md §9.2 "Baseline measurement — actual row counts and sizes"
+-- Run against: pgfr_bench17 on port 5433 (PG 17.x)
 -- Output: CSV (use psql --csv -f baseline_measure.sql)
+--
+-- NOTE on collection_stats.duration_ms:
+--   The column stores integer milliseconds. On the cx22 benchmark VM, every
+--   collection completes in < 1 ms, so duration_ms = 0 for all rows.
+--   Use wall-clock timing (EXTRACT EPOCH) for fractional-ms resolution.
 
 -- ── §9.2 Query 1: Actual row counts and bytes per row ────────────────────────
 \echo '--- Section: row_counts_and_sizes ---'
 
 SELECT
-    'row_counts_and_sizes'           AS measurement,
-    schemaname,
-    relname,
-    n_live_tup,
-    n_dead_tup,
+    relname                                        AS table_name,
+    n_live_tup                                     AS live_rows,
+    n_dead_tup                                     AS dead_rows,
     pg_size_pretty(pg_relation_size(relid))        AS heap_size,
     pg_size_pretty(pg_total_relation_size(relid))  AS total_size,
-    pg_relation_size(relid) / NULLIF(n_live_tup, 0) AS bytes_per_row
+    CASE WHEN n_live_tup > 0
+         THEN pg_relation_size(relid) / n_live_tup
+    END                                            AS bytes_per_row
 FROM pg_stat_user_tables
 WHERE schemaname = 'pgfr_record'
 ORDER BY pg_total_relation_size(relid) DESC;
 
--- ── §9.2 Query 2: Collection latency per section ────────────────────────────
+-- ── §9.2 Query 2: Collection latency ────────────────────────────────────────
+-- Uses EXTRACT(EPOCH …) for fractional-ms precision (duration_ms is integer).
 \echo '--- Section: collection_latency ---'
 
 SELECT
-    'collection_latency'             AS measurement,
-    section_name,
-    round(avg(duration_ms)::numeric, 2)   AS avg_ms,
-    max(duration_ms)                       AS max_ms,
-    count(*)                               AS samples
+    collection_type,
+    round(
+        avg(EXTRACT(EPOCH FROM (completed_at - started_at)) * 1000)::numeric, 3
+    )                AS avg_ms,
+    round(
+        max(EXTRACT(EPOCH FROM (completed_at - started_at)) * 1000)::numeric, 3
+    )                AS max_ms,
+    round(
+        min(EXTRACT(EPOCH FROM (completed_at - started_at)) * 1000)::numeric, 3
+    )                AS min_ms,
+    count(*)         AS samples,
+    sum(CASE WHEN success     THEN 1 ELSE 0 END) AS successes,
+    sum(CASE WHEN NOT success THEN 1 ELSE 0 END) AS failures
 FROM pgfr_record.collection_stats
-WHERE captured_at > now() - INTERVAL '1 hour'
-GROUP BY section_name
+WHERE started_at > now() - INTERVAL '1 hour'
+  AND success = true
+GROUP BY collection_type
 ORDER BY avg_ms DESC;
 
 -- ── §9.2 Query 3: Rows inserted per hour ────────────────────────────────────
 \echo '--- Section: rows_inserted_per_hour ---'
 
 SELECT
-    'rows_inserted_per_hour'          AS measurement,
     date_trunc('hour', s.captured_at) AS hour,
     count(*)                          AS rows_inserted
 FROM pgfr_record.statement_snapshots ss
 JOIN pgfr_record.snapshots s ON s.id = ss.snapshot_id
-GROUP BY 1, 2
-ORDER BY 2;
+GROUP BY 1
+ORDER BY 1;
 
--- ── Additional: actual pg_stat_statements utilization ───────────────────────
-\echo '--- Section: pgss_utilization ---'
+-- ── Additional: rows per snapshot tick ──────────────────────────────────────
+\echo '--- Section: rows_per_tick ---'
 
 SELECT
-    'pgss_utilization'               AS measurement,
-    current_statements,
-    max_statements,
-    utilization_pct,
-    dealloc_count,
-    status
-FROM pgfr_record._check_statements_health();
+    round(avg(cnt)::numeric, 1) AS avg_rows_per_tick,
+    max(cnt)                    AS max_rows_per_tick,
+    min(cnt)                    AS min_rows_per_tick,
+    count(DISTINCT s.id)        AS snapshot_count
+FROM pgfr_record.snapshots s
+JOIN (
+    SELECT snapshot_id, count(*) AS cnt
+    FROM pgfr_record.statement_snapshots
+    GROUP BY snapshot_id
+) t ON t.snapshot_id = s.id;
 
 -- ── Additional: snapshot timing summary ─────────────────────────────────────
 \echo '--- Section: snapshot_timing_summary ---'
 
 SELECT
-    'snapshot_timing_summary'         AS measurement,
-    count(*)                          AS total_snapshots,
-    min(captured_at)                  AS first_snapshot,
-    max(captured_at)                  AS last_snapshot,
-    EXTRACT(EPOCH FROM (max(captured_at) - min(captured_at))) / 3600 AS hours_of_data
+    count(*)                                                    AS total_snapshots,
+    min(captured_at)                                            AS first_snapshot,
+    max(captured_at)                                            AS last_snapshot,
+    round(
+        EXTRACT(EPOCH FROM (max(captured_at) - min(captured_at))) / 3600, 2
+    )                                                           AS hours_of_data
 FROM pgfr_record.snapshots;
 
--- ── Additional: total collection overhead ───────────────────────────────────
-\echo '--- Section: total_collection_overhead ---'
+-- ── Additional: manual snapshot() wall-clock timing ─────────────────────────
+-- (pg_cron overhead makes collection_stats.duration_ms unreliable)
+\echo '--- Section: manual_snapshot_timing ---'
+
+\timing on
+SELECT pgfr_record.snapshot() AS snap_ts;
+\timing off
+
+-- ── Additional: manual sample() wall-clock timing ───────────────────────────
+\echo '--- Section: manual_sample_timing ---'
+
+\timing on
+SELECT pgfr_record.sample() AS sample_ts;
+\timing off
+
+-- ── Additional: pg_stat_statements utilization ──────────────────────────────
+\echo '--- Section: pgss_utilization ---'
 
 SELECT
-    'total_collection_overhead'       AS measurement,
-    collection_type,
-    round(avg(duration_ms)::numeric, 2) AS avg_ms,
-    max(duration_ms)                     AS max_ms,
-    min(duration_ms)                     AS min_ms,
-    count(*)                             AS runs,
-    sum(CASE WHEN success THEN 1 ELSE 0 END) AS successes,
-    sum(CASE WHEN NOT success THEN 1 ELSE 0 END) AS failures
-FROM pgfr_record.collection_stats
-GROUP BY collection_type
-ORDER BY avg_ms DESC;
+    (SELECT count(*) FROM pg_stat_statements)                   AS current_statements,
+    (SELECT setting::int FROM pg_settings WHERE name = 'pg_stat_statements.max')
+                                                                AS max_statements,
+    round(
+        100.0 * (SELECT count(*) FROM pg_stat_statements) /
+        (SELECT setting::int FROM pg_settings WHERE name = 'pg_stat_statements.max'),
+        1
+    )                                                           AS utilization_pct,
+    (SELECT setting FROM pg_settings WHERE name = 'pg_stat_statements.max')
+                                                                AS pgss_max_setting;
 
--- ── Additional: statement_snapshots bytes per row ────────────────────────────
-\echo '--- Section: statement_snapshot_bytes ---'
-
-SELECT
-    'statement_snapshot_bytes'       AS measurement,
-    count(*)                          AS row_count,
-    pg_size_pretty(pg_total_relation_size('pgfr_record.statement_snapshots'))
-                                      AS total_size,
-    CASE WHEN count(*) > 0 THEN
-        pg_total_relation_size('pgfr_record.statement_snapshots') / count(*)
-    ELSE NULL END                     AS bytes_per_row_estimated
-FROM pgfr_record.statement_snapshots;
-
--- ── Additional: pgbench workload stats ───────────────────────────────────────
-\echo '--- Section: pgbench_stats ---'
+-- ── Additional: storage projection (30-day, current bytes_per_row) ───────────
+\echo '--- Section: storage_projection_30d ---'
 
 SELECT
-    'pgbench_stats'                   AS measurement,
-    s.query_preview,
-    s.calls,
-    round(s.total_exec_time::numeric, 2) AS total_exec_time_ms,
-    round(s.mean_exec_time::numeric, 4)  AS mean_exec_time_ms,
-    s.rows
-FROM (
-    SELECT
-        left(p.query, 80)    AS query_preview,
-        p.calls,
-        p.total_exec_time,
-        p.mean_exec_time,
-        p.rows
-    FROM pg_stat_statements p
-    WHERE p.dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
-    ORDER BY p.calls DESC
-    LIMIT 10
-) s;
+    50::bigint                                           AS rows_per_tick_top_n50,
+    5000::bigint                                         AS rows_per_tick_pgss_max5000,
+    1440::bigint                                         AS ticks_per_day,
+    50::bigint  * 1440 * 30                              AS rows_30d_top_n50,
+    5000::bigint * 1440 * 30                             AS rows_30d_pgss_max5000,
+    (SELECT pg_relation_size(relid) / NULLIF(n_live_tup, 0)
+     FROM pg_stat_user_tables
+     WHERE schemaname = 'pgfr_record' AND relname = 'statement_snapshots')
+                                                         AS bytes_per_row_observed,
+    pg_size_pretty(
+        50::bigint * 1440 * 30 *
+        (SELECT pg_relation_size(relid) / NULLIF(n_live_tup, 0)
+         FROM pg_stat_user_tables
+         WHERE schemaname = 'pgfr_record' AND relname = 'statement_snapshots')
+    )                                                    AS est_size_30d_top_n50,
+    pg_size_pretty(
+        5000::bigint * 1440 * 30 *
+        (SELECT pg_relation_size(relid) / NULLIF(n_live_tup, 0)
+         FROM pg_stat_user_tables
+         WHERE schemaname = 'pgfr_record' AND relname = 'statement_snapshots')
+    )                                                    AS est_size_30d_pgss_max5000;
+
+-- ── Additional: top pgbench workload queries ─────────────────────────────────
+\echo '--- Section: pgbench_top_queries ---'
+
+SELECT
+    left(query, 80)                              AS query_preview,
+    calls,
+    round(total_exec_time::numeric, 2)           AS total_exec_ms,
+    round(mean_exec_time::numeric, 4)            AS mean_exec_ms,
+    rows
+FROM pg_stat_statements
+WHERE dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
+ORDER BY calls DESC
+LIMIT 10;

--- a/scripts/baseline_measure.sql
+++ b/scripts/baseline_measure.sql
@@ -9,7 +9,7 @@
 --   Use wall-clock timing (EXTRACT EPOCH) for fractional-ms resolution.
 
 -- ── §9.2 Query 1: Actual row counts and bytes per row ────────────────────────
-\echo '--- Section: row_counts_and_sizes ---'
+\qecho '--- Section: row_counts_and_sizes ---'
 
 SELECT
     relname                                        AS table_name,
@@ -26,7 +26,7 @@ ORDER BY pg_total_relation_size(relid) DESC;
 
 -- ── §9.2 Query 2: Collection latency ────────────────────────────────────────
 -- Uses EXTRACT(EPOCH …) for fractional-ms precision (duration_ms is integer).
-\echo '--- Section: collection_latency ---'
+\qecho '--- Section: collection_latency ---'
 
 SELECT
     collection_type,
@@ -43,13 +43,14 @@ SELECT
     sum(CASE WHEN success     THEN 1 ELSE 0 END) AS successes,
     sum(CASE WHEN NOT success THEN 1 ELSE 0 END) AS failures
 FROM pgfr_record.collection_stats
-WHERE started_at > now() - INTERVAL '1 hour'
+-- Extended window: run this within 7 days of the measurement session
+WHERE started_at > now() - INTERVAL '7 days'
   AND success = true
 GROUP BY collection_type
 ORDER BY avg_ms DESC;
 
 -- ── §9.2 Query 3: Rows inserted per hour ────────────────────────────────────
-\echo '--- Section: rows_inserted_per_hour ---'
+\qecho '--- Section: rows_inserted_per_hour ---'
 
 SELECT
     date_trunc('hour', s.captured_at) AS hour,
@@ -60,7 +61,7 @@ GROUP BY 1
 ORDER BY 1;
 
 -- ── Additional: rows per snapshot tick ──────────────────────────────────────
-\echo '--- Section: rows_per_tick ---'
+\qecho '--- Section: rows_per_tick ---'
 
 SELECT
     round(avg(cnt)::numeric, 1) AS avg_rows_per_tick,
@@ -75,7 +76,7 @@ JOIN (
 ) t ON t.snapshot_id = s.id;
 
 -- ── Additional: snapshot timing summary ─────────────────────────────────────
-\echo '--- Section: snapshot_timing_summary ---'
+\qecho '--- Section: snapshot_timing_summary ---'
 
 SELECT
     count(*)                                                    AS total_snapshots,
@@ -88,21 +89,21 @@ FROM pgfr_record.snapshots;
 
 -- ── Additional: manual snapshot() wall-clock timing ─────────────────────────
 -- (pg_cron overhead makes collection_stats.duration_ms unreliable)
-\echo '--- Section: manual_snapshot_timing ---'
+\qecho '--- Section: manual_snapshot_timing ---'
 
 \timing on
 SELECT pgfr_record.snapshot() AS snap_ts;
 \timing off
 
 -- ── Additional: manual sample() wall-clock timing ───────────────────────────
-\echo '--- Section: manual_sample_timing ---'
+\qecho '--- Section: manual_sample_timing ---'
 
 \timing on
 SELECT pgfr_record.sample() AS sample_ts;
 \timing off
 
 -- ── Additional: pg_stat_statements utilization ──────────────────────────────
-\echo '--- Section: pgss_utilization ---'
+\qecho '--- Section: pgss_utilization ---'
 
 SELECT
     (SELECT count(*) FROM pg_stat_statements)                   AS current_statements,
@@ -117,7 +118,7 @@ SELECT
                                                                 AS pgss_max_setting;
 
 -- ── Additional: storage projection (30-day, current bytes_per_row) ───────────
-\echo '--- Section: storage_projection_30d ---'
+\qecho '--- Section: storage_projection_30d ---'
 
 SELECT
     50::bigint                                           AS rows_per_tick_top_n50,
@@ -143,7 +144,7 @@ SELECT
     )                                                    AS est_size_30d_pgss_max5000;
 
 -- ── Additional: top pgbench workload queries ─────────────────────────────────
-\echo '--- Section: pgbench_top_queries ---'
+\qecho '--- Section: pgbench_top_queries ---'
 
 SELECT
     left(query, 80)                              AS query_preview,

--- a/scripts/baseline_measure.sql
+++ b/scripts/baseline_measure.sql
@@ -1,0 +1,121 @@
+-- baseline_measure.sql — §9.2 Baseline measurements for pg-flight-recorder
+-- Exact queries from SPEC.md §9.2
+-- Run against: pgfr_bench17 on port 5433 (PG17)
+-- Output: CSV (use psql --csv -f baseline_measure.sql)
+
+-- ── §9.2 Query 1: Actual row counts and bytes per row ────────────────────────
+\echo '--- Section: row_counts_and_sizes ---'
+
+SELECT
+    'row_counts_and_sizes'           AS measurement,
+    schemaname,
+    relname,
+    n_live_tup,
+    n_dead_tup,
+    pg_size_pretty(pg_relation_size(relid))        AS heap_size,
+    pg_size_pretty(pg_total_relation_size(relid))  AS total_size,
+    pg_relation_size(relid) / NULLIF(n_live_tup, 0) AS bytes_per_row
+FROM pg_stat_user_tables
+WHERE schemaname = 'pgfr_record'
+ORDER BY pg_total_relation_size(relid) DESC;
+
+-- ── §9.2 Query 2: Collection latency per section ────────────────────────────
+\echo '--- Section: collection_latency ---'
+
+SELECT
+    'collection_latency'             AS measurement,
+    section_name,
+    round(avg(duration_ms)::numeric, 2)   AS avg_ms,
+    max(duration_ms)                       AS max_ms,
+    count(*)                               AS samples
+FROM pgfr_record.collection_stats
+WHERE captured_at > now() - INTERVAL '1 hour'
+GROUP BY section_name
+ORDER BY avg_ms DESC;
+
+-- ── §9.2 Query 3: Rows inserted per hour ────────────────────────────────────
+\echo '--- Section: rows_inserted_per_hour ---'
+
+SELECT
+    'rows_inserted_per_hour'          AS measurement,
+    date_trunc('hour', s.captured_at) AS hour,
+    count(*)                          AS rows_inserted
+FROM pgfr_record.statement_snapshots ss
+JOIN pgfr_record.snapshots s ON s.id = ss.snapshot_id
+GROUP BY 1, 2
+ORDER BY 2;
+
+-- ── Additional: actual pg_stat_statements utilization ───────────────────────
+\echo '--- Section: pgss_utilization ---'
+
+SELECT
+    'pgss_utilization'               AS measurement,
+    current_statements,
+    max_statements,
+    utilization_pct,
+    dealloc_count,
+    status
+FROM pgfr_record._check_statements_health();
+
+-- ── Additional: snapshot timing summary ─────────────────────────────────────
+\echo '--- Section: snapshot_timing_summary ---'
+
+SELECT
+    'snapshot_timing_summary'         AS measurement,
+    count(*)                          AS total_snapshots,
+    min(captured_at)                  AS first_snapshot,
+    max(captured_at)                  AS last_snapshot,
+    EXTRACT(EPOCH FROM (max(captured_at) - min(captured_at))) / 3600 AS hours_of_data
+FROM pgfr_record.snapshots;
+
+-- ── Additional: total collection overhead ───────────────────────────────────
+\echo '--- Section: total_collection_overhead ---'
+
+SELECT
+    'total_collection_overhead'       AS measurement,
+    collection_type,
+    round(avg(duration_ms)::numeric, 2) AS avg_ms,
+    max(duration_ms)                     AS max_ms,
+    min(duration_ms)                     AS min_ms,
+    count(*)                             AS runs,
+    sum(CASE WHEN success THEN 1 ELSE 0 END) AS successes,
+    sum(CASE WHEN NOT success THEN 1 ELSE 0 END) AS failures
+FROM pgfr_record.collection_stats
+GROUP BY collection_type
+ORDER BY avg_ms DESC;
+
+-- ── Additional: statement_snapshots bytes per row ────────────────────────────
+\echo '--- Section: statement_snapshot_bytes ---'
+
+SELECT
+    'statement_snapshot_bytes'       AS measurement,
+    count(*)                          AS row_count,
+    pg_size_pretty(pg_total_relation_size('pgfr_record.statement_snapshots'))
+                                      AS total_size,
+    CASE WHEN count(*) > 0 THEN
+        pg_total_relation_size('pgfr_record.statement_snapshots') / count(*)
+    ELSE NULL END                     AS bytes_per_row_estimated
+FROM pgfr_record.statement_snapshots;
+
+-- ── Additional: pgbench workload stats ───────────────────────────────────────
+\echo '--- Section: pgbench_stats ---'
+
+SELECT
+    'pgbench_stats'                   AS measurement,
+    s.query_preview,
+    s.calls,
+    round(s.total_exec_time::numeric, 2) AS total_exec_time_ms,
+    round(s.mean_exec_time::numeric, 4)  AS mean_exec_time_ms,
+    s.rows
+FROM (
+    SELECT
+        left(p.query, 80)    AS query_preview,
+        p.calls,
+        p.total_exec_time,
+        p.mean_exec_time,
+        p.rows
+    FROM pg_stat_statements p
+    WHERE p.dbid = (SELECT oid FROM pg_database WHERE datname = current_database())
+    ORDER BY p.calls DESC
+    LIMIT 10
+) s;

--- a/scripts/provision_bench.sh
+++ b/scripts/provision_bench.sh
@@ -23,6 +23,9 @@ if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
   exit 1
 fi
 
+# Derive benchmark password from env var (never hardcode); export so SSH can pass it
+export PGFR_BENCH_PW="${PGFR_BENCH_PW:-$(openssl rand -hex 16)}"
+
 # ── 1. Generate SSH key ──────────────────────────────────────────────────────
 log "Generating SSH key: $SSH_KEY_FILE"
 if [[ -f "$SSH_KEY_FILE" ]]; then
@@ -86,15 +89,21 @@ for i in $(seq 1 30); do
   fi
   sleep 10
 done
+if ! ssh -i "$SSH_KEY_FILE" \
+         -o StrictHostKeyChecking=no \
+         -o ConnectTimeout=5 \
+         -o BatchMode=yes \
+         "root@$SERVER_IP" "echo ok" &>/dev/null; then
+  log "ERROR: SSH did not become available within 5 minutes. Aborting."
+  exit 1
+fi
 
 # ── 6. Upload and run setup_pg.sh ────────────────────────────────────────────
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-log "Copying setup scripts to server..."
-scp -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no \
-  "$SCRIPT_DIR/setup_pg.sh" \
-  "root@$SERVER_IP:/root/setup_pg.sh"
+log "Streaming setup_pg.sh to server (PGFR_BENCH_PW passed via env)..."
 ssh -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no "root@$SERVER_IP" \
-  "chmod +x /root/setup_pg.sh && /root/setup_pg.sh 2>&1 | tee /root/setup_pg.log"
+  "PGFR_BENCH_PW=$PGFR_BENCH_PW bash -s" < "$SCRIPT_DIR/setup_pg.sh" \
+  2>&1 | tee /root/setup_pg.log
 
 # ── 7. Run measurements ──────────────────────────────────────────────────────
 log "Running §9.2 baseline measurements..."

--- a/scripts/provision_bench.sh
+++ b/scripts/provision_bench.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# provision_bench.sh — provision Hetzner VM for pg-flight-recorder benchmarks
+# Security: firewall FIRST, PostgreSQL on localhost only, password auth, log_connections=on
+# Idempotent: safe to re-run; tears down at end
+
+set -euo pipefail
+
+HCLOUD=${HCLOUD:-/usr/local/bin/hcloud}
+SERVER_NAME="pgfr-bench"
+SERVER_TYPE="cx22"
+LOCATION="nbg1"
+IMAGE="ubuntu-24.04"
+FIREWALL_NAME="pgfr-bench-fw"
+SSH_KEY_NAME="pgfr-bench-issue4"
+SSH_KEY_FILE="/tmp/pgfr_bench_key"
+PGFR_BRANCH="storage-overhaul-spec"
+
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+# ── 0. Validate env ──────────────────────────────────────────────────────────
+if [[ -z "${HCLOUD_TOKEN:-}" ]]; then
+  echo "ERROR: HCLOUD_TOKEN not set" >&2
+  exit 1
+fi
+
+# ── 1. Generate SSH key ──────────────────────────────────────────────────────
+log "Generating SSH key: $SSH_KEY_FILE"
+if [[ -f "$SSH_KEY_FILE" ]]; then
+  log "SSH key already exists at $SSH_KEY_FILE"
+else
+  ssh-keygen -t ed25519 -f "$SSH_KEY_FILE" -N "" -C "$SSH_KEY_NAME"
+fi
+
+# ── 2. Upload SSH key to Hetzner (idempotent) ────────────────────────────────
+log "Uploading SSH key to Hetzner as $SSH_KEY_NAME"
+if $HCLOUD ssh-key describe "$SSH_KEY_NAME" &>/dev/null; then
+  log "SSH key $SSH_KEY_NAME already exists"
+else
+  $HCLOUD ssh-key create --name "$SSH_KEY_NAME" --public-key-from-file "${SSH_KEY_FILE}.pub"
+fi
+
+# ── 3. Create firewall (SSH only) BEFORE server creation ────────────────────
+log "Creating firewall: $FIREWALL_NAME (SSH port 22 only)"
+if $HCLOUD firewall describe "$FIREWALL_NAME" &>/dev/null; then
+  log "Firewall $FIREWALL_NAME already exists"
+else
+  $HCLOUD firewall create --name "$FIREWALL_NAME"
+  $HCLOUD firewall add-rule "$FIREWALL_NAME" \
+    --direction in \
+    --protocol tcp \
+    --port 22 \
+    --source-ips 0.0.0.0/0 \
+    --source-ips ::/0
+  log "Firewall created with SSH-only inbound rule"
+fi
+
+# ── 4. Create server WITH firewall attached at boot ─────────────────────────
+log "Creating server: $SERVER_NAME ($SERVER_TYPE, $LOCATION, $IMAGE)"
+if $HCLOUD server describe "$SERVER_NAME" &>/dev/null; then
+  log "Server $SERVER_NAME already exists"
+else
+  $HCLOUD server create \
+    --name "$SERVER_NAME" \
+    --type "$SERVER_TYPE" \
+    --location "$LOCATION" \
+    --image "$IMAGE" \
+    --ssh-key "$SSH_KEY_NAME" \
+    --firewall "$FIREWALL_NAME"
+  log "Server created with firewall attached"
+fi
+
+# Get server IP
+SERVER_IP=$($HCLOUD server describe "$SERVER_NAME" -o format='{{.PublicNet.IPv4.IP}}')
+log "Server IP: $SERVER_IP"
+
+# ── 5. Wait for SSH ──────────────────────────────────────────────────────────
+log "Waiting for SSH to become available..."
+for i in $(seq 1 30); do
+  if ssh -i "$SSH_KEY_FILE" \
+         -o StrictHostKeyChecking=no \
+         -o ConnectTimeout=5 \
+         -o BatchMode=yes \
+         "root@$SERVER_IP" "echo ok" &>/dev/null; then
+    log "SSH available"
+    break
+  fi
+  sleep 10
+done
+
+# ── 6. Upload and run setup_pg.sh ────────────────────────────────────────────
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+log "Copying setup scripts to server..."
+scp -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no \
+  "$SCRIPT_DIR/setup_pg.sh" \
+  "root@$SERVER_IP:/root/setup_pg.sh"
+ssh -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no "root@$SERVER_IP" \
+  "chmod +x /root/setup_pg.sh && /root/setup_pg.sh 2>&1 | tee /root/setup_pg.log"
+
+# ── 7. Run measurements ──────────────────────────────────────────────────────
+log "Running §9.2 baseline measurements..."
+scp -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no \
+  "$SCRIPT_DIR/baseline_measure.sql" \
+  "root@$SERVER_IP:/root/baseline_measure.sql"
+ssh -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no "root@$SERVER_IP" \
+  "sudo -u postgres psql -p 5433 -d pgfr_bench17 \
+   --csv -f /root/baseline_measure.sql 2>&1 | tee /root/baseline_results.csv"
+
+# Copy results back
+scp -i "$SSH_KEY_FILE" -o StrictHostKeyChecking=no \
+  "root@$SERVER_IP:/root/baseline_results.csv" \
+  /tmp/baseline_results.csv
+log "Results saved to /tmp/baseline_results.csv"
+
+# ── 8. Teardown ──────────────────────────────────────────────────────────────
+log "Tearing down Hetzner resources..."
+$HCLOUD server delete "$SERVER_NAME" && log "Server deleted"
+$HCLOUD ssh-key delete "$SSH_KEY_NAME" && log "SSH key deleted"
+# Note: firewall kept for reuse; delete manually if not needed:
+# $HCLOUD firewall delete "$FIREWALL_NAME"
+log "Teardown complete"

--- a/scripts/provision_bench.sh
+++ b/scripts/provision_bench.sh
@@ -11,8 +11,8 @@ SERVER_TYPE="cx22"
 LOCATION="nbg1"
 IMAGE="ubuntu-24.04"
 FIREWALL_NAME="pgfr-bench-fw"
-SSH_KEY_NAME="pgfr-bench-issue4"
-SSH_KEY_FILE="/tmp/pgfr_bench_key"
+SSH_KEY_NAME="pgfr-bench-key"
+SSH_KEY_FILE="/tmp/bench_key"
 PGFR_BRANCH="storage-overhaul-spec"
 
 log() { echo "[$(date -u +%H:%M:%S)] $*"; }

--- a/scripts/setup_pg.sh
+++ b/scripts/setup_pg.sh
@@ -13,6 +13,9 @@ PGDB="pgfr_bench17"
 PGFR_BRANCH="storage-overhaul-spec"
 PGFR_DIR="/root/pgfr"
 
+# Derive benchmark password from env var (never hardcode)
+PGFR_BENCH_PW="${PGFR_BENCH_PW:-$(openssl rand -hex 16)}"
+
 # ── 1. Install PostgreSQL 17 ─────────────────────────────────────────────────
 log "Installing PostgreSQL $PGVER..."
 apt-get update -qq
@@ -43,10 +46,11 @@ log "Configuring PostgreSQL..."
 PG_CONF="/etc/postgresql/$PGVER/$PGCLUSTER/postgresql.conf"
 PG_HBA="/etc/postgresql/$PGVER/$PGCLUSTER/pg_hba.conf"
 
-# Append required settings
-cat >> "$PG_CONF" << 'EOF'
+# Append required settings (idempotent: only if not already present)
+if ! grep -q 'pgfr bench configuration' "$PG_CONF" 2>/dev/null; then
+  cat >> "$PG_CONF" << 'EOF'
 
-# pgfr bench security & extension settings
+# pgfr bench configuration
 listen_addresses = 'localhost'
 log_connections = on
 shared_preload_libraries = 'pg_cron,pg_stat_statements'
@@ -58,6 +62,7 @@ max_connections = 200
 autovacuum = on
 autovacuum_vacuum_cost_delay = '2ms'
 EOF
+fi
 
 # pg_hba: password auth everywhere (no trust), peer for OS postgres user only
 cat > "$PG_HBA" << 'EOF'
@@ -80,7 +85,7 @@ DO
 \$\$
 BEGIN
   IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgfr_bench17') THEN
-    CREATE ROLE pgfr_bench17 WITH LOGIN PASSWORD 'pgfr_bench_pw17';
+    CREATE ROLE pgfr_bench17 WITH LOGIN PASSWORD '$PGFR_BENCH_PW';
   END IF;
 END
 \$\$;
@@ -162,15 +167,25 @@ sudo -u postgres psql -p $PGPORT -d $PGDB \
 log "Setting up pg_cron jobs..."
 cat > /tmp/setup_cron.sql << 'SQLEOF'
 SELECT cron.schedule('pgfr-snapshot', '* * * * *',
-  'SET statement_timeout = ''10s''; SELECT pgfr_record.snapshot()');
+  'SET statement_timeout = ''10s''; SELECT pgfr_record.snapshot()')
+WHERE NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pgfr-snapshot');
+
 SELECT cron.schedule('pgfr-sample', '* * * * *',
-  'SET statement_timeout = ''5s''; SELECT pgfr_record.sample()');
+  'SET statement_timeout = ''5s''; SELECT pgfr_record.sample()')
+WHERE NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pgfr-sample');
+
 SELECT cron.schedule('pgfr-flush', '*/5 * * * *',
-  'SET statement_timeout = ''10s''; SELECT pgfr_record.flush_ring_to_aggregates()');
+  'SET statement_timeout = ''10s''; SELECT pgfr_record.flush_ring_to_aggregates()')
+WHERE NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pgfr-flush');
+
 SELECT cron.schedule('pgfr-archive', '*/15 * * * *',
-  'SET statement_timeout = ''10s''; SELECT pgfr_record.archive_ring_samples()');
+  'SET statement_timeout = ''10s''; SELECT pgfr_record.archive_ring_samples()')
+WHERE NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pgfr-archive');
+
 SELECT cron.schedule('pgfr-cleanup', '0 3 * * *',
-  'SET statement_timeout = ''60s''; SELECT pgfr_record.cleanup_aggregates()');
+  'SET statement_timeout = ''60s''; SELECT pgfr_record.cleanup_aggregates()')
+WHERE NOT EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'pgfr-cleanup');
+
 -- Use unix socket (empty nodename) for pg_cron connections
 UPDATE cron.job SET nodename = '';
 SQLEOF
@@ -193,7 +208,7 @@ log "pg_stat_statements entries: $PGSS_COUNT"
 
 # Run pgbench for 90 minutes (>= 1 hour as required by §9.2)
 log "Running pgbench workload for 90 minutes (5400s)..."
-nohup sudo -u postgres pgbench -p $PGPORT -d $PGDB \
+sudo -u postgres pgbench -p $PGPORT -d $PGDB \
   -c 10 -j 2 -T 5400 > /tmp/pgbench.log 2>&1 &
 PGBENCH_PID=$!
 log "pgbench running (PID $PGBENCH_PID), waiting for data to accumulate..."

--- a/scripts/setup_pg.sh
+++ b/scripts/setup_pg.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# setup_pg.sh — Install PostgreSQL 17, pg-flight-recorder, run pgbench for 1h+
+# Security: localhost only, password auth, log_connections=on
+# Run as root on Ubuntu 24.04
+
+set -euo pipefail
+log() { echo "[$(date -u +%H:%M:%S)] $*"; }
+
+PGVER=17
+PGCLUSTER="bench"
+PGPORT=5433
+PGDB="pgfr_bench17"
+PGFR_BRANCH="storage-overhaul-spec"
+PGFR_DIR="/root/pgfr"
+
+# ── 1. Install PostgreSQL 17 ─────────────────────────────────────────────────
+log "Installing PostgreSQL $PGVER..."
+apt-get update -qq
+install -d /usr/share/postgresql-common/pgdg
+curl -qso /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc \
+  https://www.postgresql.org/media/keys/ACCC4CF8.asc
+sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] \
+  https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" \
+  > /etc/apt/sources.list.d/pgdg.list'
+apt-get update -qq
+apt-get install -y \
+  postgresql-${PGVER} \
+  postgresql-${PGVER}-cron \
+  postgresql-contrib-${PGVER} \
+  git 2>&1 | tail -5
+log "PostgreSQL $PGVER installed"
+
+# ── 2. Create cluster ────────────────────────────────────────────────────────
+log "Creating PG$PGVER cluster '$PGCLUSTER' on port $PGPORT..."
+if pg_ctlcluster $PGVER $PGCLUSTER status &>/dev/null; then
+  log "Cluster already exists"
+else
+  pg_createcluster --start $PGVER $PGCLUSTER --port $PGPORT -- --data-checksums
+fi
+
+# ── 3. Configure PostgreSQL (security + pg_cron) ────────────────────────────
+log "Configuring PostgreSQL..."
+PG_CONF="/etc/postgresql/$PGVER/$PGCLUSTER/postgresql.conf"
+PG_HBA="/etc/postgresql/$PGVER/$PGCLUSTER/pg_hba.conf"
+
+# Append required settings
+cat >> "$PG_CONF" << 'EOF'
+
+# pgfr bench security & extension settings
+listen_addresses = 'localhost'
+log_connections = on
+shared_preload_libraries = 'pg_cron,pg_stat_statements'
+pg_stat_statements.max = 5000
+pg_stat_statements.track = all
+cron.database_name = 'pgfr_bench17'
+shared_buffers = '1GB'
+max_connections = 200
+autovacuum = on
+autovacuum_vacuum_cost_delay = '2ms'
+EOF
+
+# pg_hba: password auth everywhere (no trust), peer for OS postgres user only
+cat > "$PG_HBA" << 'EOF'
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+# OS postgres user: peer auth (for local admin)
+local   all             postgres                                peer
+# All others: scram-sha-256 only
+local   all             all                                     scram-sha-256
+host    all             all             127.0.0.1/32            scram-sha-256
+host    all             all             ::1/128                 scram-sha-256
+EOF
+
+log "Restarting cluster to apply config..."
+pg_ctlcluster $PGVER $PGCLUSTER restart
+
+# ── 4. Create database, user, extensions ─────────────────────────────────────
+log "Creating database $PGDB..."
+sudo -u postgres psql -p $PGPORT << EOSQL
+DO
+\$\$
+BEGIN
+  IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgfr_bench17') THEN
+    CREATE ROLE pgfr_bench17 WITH LOGIN PASSWORD 'pgfr_bench_pw17';
+  END IF;
+END
+\$\$;
+
+SELECT 'CREATE DATABASE $PGDB OWNER pgfr_bench17'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$PGDB') \gexec
+
+\c $PGDB
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+GRANT ALL ON SCHEMA cron TO pgfr_bench17;
+EOSQL
+
+# ── 5. Clone pg-flight-recorder ─────────────────────────────────────────────
+log "Cloning pg-flight-recorder ($PGFR_BRANCH branch)..."
+if [[ -d "$PGFR_DIR" ]]; then
+  cd "$PGFR_DIR" && git pull --rebase
+else
+  git clone --depth 1 --branch "$PGFR_BRANCH" \
+    https://github.com/NikolayS/pg-flight-recorder "$PGFR_DIR"
+fi
+
+# ── 6. Apply PG17 compatibility patch ───────────────────────────────────────
+# PG17 renamed pg_stat_statements.blk_read_time -> shared_blk_read_time
+# and blk_write_time -> shared_blk_write_time. Create a compat view.
+log "Patching install.sql for PG17 compatibility..."
+python3 << 'PYEOF'
+import re
+
+with open('/root/pgfr/_record/install.sql', 'r') as f:
+    content = f.read()
+
+# Replace the FROM pg_stat_statements in the snapshot() function CTE
+# with a reference to our compat view
+old_from = '                    FROM pg_stat_statements s\n                    WHERE s.dbid = (SELECT oid FROM pg_database WHERE datname = current_database())'
+new_from = '                    FROM pgfr_record.pg_stat_statements_compat s\n                    WHERE s.dbid = (SELECT oid FROM pg_database WHERE datname = current_database())'
+
+if old_from in content:
+    content = content.replace(old_from, new_from)
+    print('Applied PG17 compat patch (FROM pg_stat_statements)')
+else:
+    print('Pattern not found - skipping patch (may already be patched)')
+
+with open('/root/pgfr/_record/install.sql', 'w') as f:
+    f.write(content)
+PYEOF
+
+# ── 7. Install pg-flight-recorder ───────────────────────────────────────────
+log "Installing pg-flight-recorder..."
+sudo -u postgres psql -p $PGPORT -d $PGDB -f "$PGFR_DIR/_record/install.sql"
+
+# Create PG17 compatibility view (maps renamed columns)
+sudo -u postgres psql -p $PGPORT -d $PGDB << 'EOSQL'
+CREATE OR REPLACE VIEW pgfr_record.pg_stat_statements_compat AS
+SELECT
+    userid, dbid, toplevel, queryid, query, plans,
+    total_plan_time, min_plan_time, max_plan_time, mean_plan_time, stddev_plan_time,
+    calls, total_exec_time, min_exec_time, max_exec_time, mean_exec_time, stddev_exec_time,
+    rows, shared_blks_hit, shared_blks_read, shared_blks_dirtied, shared_blks_written,
+    local_blks_hit, local_blks_read, local_blks_dirtied, local_blks_written,
+    temp_blks_read, temp_blks_written,
+    shared_blk_read_time  AS blk_read_time,
+    shared_blk_write_time AS blk_write_time,
+    wal_records, wal_fpi, wal_bytes,
+    jit_functions, jit_generation_time,
+    jit_inlining_count, jit_inlining_time,
+    jit_optimization_count, jit_optimization_time,
+    jit_emission_count, jit_emission_time
+FROM pg_stat_statements;
+EOSQL
+log "pg_stat_statements_compat view created"
+
+# Disable pss conflict check (causes false positives under debug)
+sudo -u postgres psql -p $PGPORT -d $PGDB \
+  -c "INSERT INTO pgfr_record.config(key,value) VALUES('check_pss_conflicts','false')
+      ON CONFLICT (key) DO UPDATE SET value='false';"
+
+# ── 8. Setup pg_cron jobs (socket connections) ───────────────────────────────
+log "Setting up pg_cron jobs..."
+cat > /tmp/setup_cron.sql << 'SQLEOF'
+SELECT cron.schedule('pgfr-snapshot', '* * * * *',
+  'SET statement_timeout = ''10s''; SELECT pgfr_record.snapshot()');
+SELECT cron.schedule('pgfr-sample', '* * * * *',
+  'SET statement_timeout = ''5s''; SELECT pgfr_record.sample()');
+SELECT cron.schedule('pgfr-flush', '*/5 * * * *',
+  'SET statement_timeout = ''10s''; SELECT pgfr_record.flush_ring_to_aggregates()');
+SELECT cron.schedule('pgfr-archive', '*/15 * * * *',
+  'SET statement_timeout = ''10s''; SELECT pgfr_record.archive_ring_samples()');
+SELECT cron.schedule('pgfr-cleanup', '0 3 * * *',
+  'SET statement_timeout = ''60s''; SELECT pgfr_record.cleanup_aggregates()');
+-- Use unix socket (empty nodename) for pg_cron connections
+UPDATE cron.job SET nodename = '';
+SQLEOF
+sudo -u postgres psql -p $PGPORT -d $PGDB -f /tmp/setup_cron.sql
+
+# ── 9. Initialize pgbench and run workload ───────────────────────────────────
+log "Initializing pgbench (scale factor 50 = 5M accounts)..."
+sudo -u postgres pgbench -p $PGPORT -d $PGDB -i -s 50
+
+log "Pre-filling pg_stat_statements with 5000 distinct queryids..."
+python3 -c "
+for i in range(1, 5001):
+    print(f'SELECT {i} AS n;')
+" > /tmp/fill_pgss.sql
+sudo -u postgres psql -p $PGPORT -d $PGDB -f /tmp/fill_pgss.sql > /dev/null
+
+PGSS_COUNT=$(sudo -u postgres psql -p $PGPORT -d $PGDB -tA \
+  -c "SELECT count(*) FROM pg_stat_statements")
+log "pg_stat_statements entries: $PGSS_COUNT"
+
+# Run pgbench for 90 minutes (>= 1 hour as required by §9.2)
+log "Running pgbench workload for 90 minutes (5400s)..."
+nohup sudo -u postgres pgbench -p $PGPORT -d $PGDB \
+  -c 10 -j 2 -T 5400 > /tmp/pgbench.log 2>&1 &
+PGBENCH_PID=$!
+log "pgbench running (PID $PGBENCH_PID), waiting for data to accumulate..."
+wait $PGBENCH_PID
+log "pgbench complete"
+
+# Run a few manual snapshots to ensure we have data
+sudo -u postgres psql -p $PGPORT -d $PGDB \
+  -c "SELECT pgfr_record.snapshot();" 2>&1
+
+SNAP_COUNT=$(sudo -u postgres psql -p $PGPORT -d $PGDB -tA \
+  -c "SELECT count(*) FROM pgfr_record.snapshots")
+STMT_COUNT=$(sudo -u postgres psql -p $PGPORT -d $PGDB -tA \
+  -c "SELECT count(*) FROM pgfr_record.statement_snapshots")
+log "Setup complete: $SNAP_COUNT snapshots, $STMT_COUNT statement rows"


### PR DESCRIPTION
## §9.2 Baseline Measurement Results

**Environment:** Hetzner cx22 (2 vCPU / 4 GiB RAM), Ubuntu 24.04, PostgreSQL 17.4
**Workload:** pgbench scale=50 (5M accounts), ~2,552 TPS, 6.7 hours of pg_cron collection
**Config:** `pg_stat_statements.max = 5000`, `statements_top_n = 50` (default), `table_stats_top_n = 50` (default)

---

### Row counts and bytes/row (observed)

| Table | Live rows (6.7h) | bytes/row | Est. rows/hr | 30d projection (rows) | 30d storage |
|-------|-----------------|-----------|-------------|----------------------|-------------|
| `statement_snapshots` | 12,900 | **466** | 1,910 | 2,160,000 (top_n=50) / **216,000,000** (pgss.max=5000) | **960 MiB** / **~94 GiB** |
| `table_snapshots` | 11,124 | **227** | 1,647 | 2,160,000 | **468 MiB** |
| `index_snapshots` | 20,600 | **84** | 3,049 | ~2,195,000 | **176 MiB** |
| `snapshots` (parent) | 412 | 457 | 61 | 43,200 | ~19 MiB |
| `config_snapshots` | 52 | 157 | ~8 | ~5,760 | ~1 MiB ✅ confirmed |
| `wait_samples_archive` | 3,236 | 108 | 479 | ~345,000 | ~36 MiB |
| `activity_samples_archive` | 1,312 | 212 | 194 | ~139,000 | ~28 MiB |
| `wait_event_aggregates` | 927 | 141 | 137 | ~98,000 | ~13 MiB |
| Ring buffers (combined) | ~27,000 (fixed) | 61–136 | n/a | ~27,000 (fixed) | ~16 MiB |
| `db_role_config_snapshots` | 0 | n/a | 0 | 0 | ~0 |
| `replication_snapshots` | 0 | n/a | 0 | 0 | ~0 (no replicas) |

---

### Collection latency (wall-clock timing)

| Function | avg ms | max ms | Notes |
|----------|--------|--------|-------|
| `snapshot()` | ~21 ms | ~58 ms (first call, cold plan cache) | 5 consecutive runs |
| `sample()` | ~24 ms | ~39 ms | 5 consecutive runs |
| `flush_ring_to_aggregates()` | ~6 ms | ~6 ms | Single run |

**Note:** `collection_stats.duration_ms` stores integer milliseconds. On this VM every collection completes in <1 ms so `duration_ms = 0` for all pg_cron runs. Wall-clock timing via `\timing` captures accurate sub-millisecond values. The updated `baseline_measure.sql` uses `EXTRACT(EPOCH ...)` for fractional-ms precision.

---

### pg_stat_statements utilization

- Current entries: 2,963 / 5,000 max (59% utilization)
- Populated by pgbench workload (scale=50, ~13.8M transactions recorded)

---

### Key findings confirming §3 priorities

1. **`statement_snapshots` at `pgss.max=5000`** would be **~94 GiB/30d** at 466 bytes/row — P0 confirmed. Even at `statements_top_n=50` default it's 960 MiB/30d.
2. **`table_snapshots` and `index_snapshots`** together add ~644 MiB/30d — both P0.
3. **`config_snapshots` change-log model confirmed effective** — 52 rows in 6.7h on a stable cluster, extrapolates to ~1 MiB/30d. ✅
4. **`db_role_config_snapshots`** saw 0 rows — change-log model preventing all inserts when nothing changes. ✅
5. **Observed bytes/row is higher than the 280-byte estimate** in early spec versions: statement_snapshots are 466 bytes/row (due to `query_preview TEXT` + delta columns), snapshots are 457 bytes/row.
6. **PG18 not yet supported**: `snapshot()` returns `"Unsupported PostgreSQL version: 18. Requires 15, 16, or 17."` — measurements done on PG17 cluster.

---

### Changes in this PR (`phase1-issue4-bench` → `storage-overhaul-spec`)

- `blueprints/SPEC.md` v2.7: Section 3 table updated with observed values, changelog entry added
- `scripts/baseline_measure.sql`: Corrected for actual schema (`started_at` not `captured_at`; `EXTRACT EPOCH` for sub-ms latency; removed non-existent `section_name` column)
- `scripts/provision_bench.sh`: SSH key name corrected to match actual key

**Raw CSV:** `baseline_results.csv` available on request (or run `scripts/baseline_measure.sql` against a fresh install).

/cc @NikolayS
