### PR TITLE
feat(phase1): migration path for existing installs — migrate_to_v2()

### DIFF
--- a/_record/migrate_phase1.sql
+++ b/_record/migrate_phase1.sql
@@ -37,7 +37,6 @@ declare
         'table_snapshots',
         'index_snapshots'
     ];
-    v_already_done boolean := false;
     v_any_legacy   boolean := false;
 begin
     -- ----------------------------------------------------------------
@@ -106,7 +105,6 @@ begin
                 raise notice 'migrate_to_v2: renamed pgfr_record.% → pgfr_record.%',
                     v_table_name, v_legacy_name;
                 v_actions := v_actions || format('renamed %s → %s', v_table_name, v_legacy_name);
-                v_already_done := false;
 
             elsif v_legacy_exists and not v_original_exists then
                 raise notice 'migrate_to_v2: pgfr_record.% already renamed to pgfr_record.% — skipping',
@@ -121,7 +119,6 @@ begin
                     'WARNING: both %s and %s exist — skipped',
                     v_table_name, v_legacy_name
                 );
-                v_already_done := false;
 
             else
                 -- neither original nor legacy exists — nothing to migrate for this table

--- a/_record/migrate_phase1.sql
+++ b/_record/migrate_phase1.sql
@@ -1,0 +1,184 @@
+-- Phase 1 Migration: old tables → v2 partitioned tables
+-- Safe to run on live system. Idempotent.
+-- Run AFTER installing the new _record/install.sql (which adds v2 tables).
+--
+-- Usage:
+--   SELECT pgfr_record.migrate_to_v2();
+--
+-- What it does:
+--   1. Verifies v2 tables exist (raises ERROR if install.sql has not been run)
+--   2. Renames old tables to _legacy suffix (idempotent — skips if already renamed)
+--   3. Creates backwards-compat views so existing SELECT queries continue to work
+--   4. Returns a text summary of actions taken
+--
+-- Rollback:
+--   To undo: rename _legacy tables back and drop the views.
+--   Old data is preserved in the _legacy tables — nothing is deleted.
+
+-- ============================================================================
+-- migrate_to_v2() — main migration entry point
+-- ============================================================================
+create or replace function pgfr_record.migrate_to_v2()
+returns text
+language plpgsql
+as $$
+declare
+    v_actions      text[] := '{}';
+    v_summary      text;
+    v_v2_missing   text[] := '{}';
+    v_table_name   text;
+    v_v2_tables    text[] := array[
+        'statement_snapshots_v2',
+        'table_snapshots_v2',
+        'index_snapshots_v2'
+    ];
+    v_old_tables   text[] := array[
+        'statement_snapshots',
+        'table_snapshots',
+        'index_snapshots'
+    ];
+    v_already_done boolean := true;
+begin
+    -- ----------------------------------------------------------------
+    -- Step 1: verify v2 tables exist.
+    -- If any are missing, raise an error telling the operator what to do.
+    -- ----------------------------------------------------------------
+    foreach v_table_name in array v_v2_tables loop
+        if not exists (
+            select 1
+            from pg_catalog.pg_class c
+            join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+            where n.nspname = 'pgfr_record'
+              and c.relname = v_table_name
+              and c.relkind in ('r', 'p')  -- regular table or partitioned table
+        ) then
+            v_v2_missing := v_v2_missing || v_table_name;
+        end if;
+    end loop;
+
+    if array_length(v_v2_missing, 1) > 0 then
+        raise exception
+            e'migrate_to_v2() aborted: v2 tables are missing: %\n'
+            'Run the new _record/install.sql first, then retry migration.\n'
+            'Example: \\i _record/install.sql',
+            array_to_string(v_v2_missing, ', ');
+    end if;
+
+    -- ----------------------------------------------------------------
+    -- Step 2: rename old tables to _legacy (idempotent).
+    -- Only rename tables that still have their original names.
+    -- ----------------------------------------------------------------
+    foreach v_table_name in array v_old_tables loop
+        declare
+            v_original_exists boolean;
+            v_legacy_exists   boolean;
+            v_legacy_name     text := v_table_name || '_legacy';
+        begin
+            v_original_exists := exists (
+                select 1
+                from pg_catalog.pg_class c
+                join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+                where n.nspname = 'pgfr_record'
+                  and c.relname = v_table_name
+                  and c.relkind = 'r'  -- plain heap table (not partitioned)
+            );
+
+            v_legacy_exists := exists (
+                select 1
+                from pg_catalog.pg_class c
+                join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+                where n.nspname = 'pgfr_record'
+                  and c.relname = v_legacy_name
+                  and c.relkind = 'r'
+            );
+
+            if v_original_exists and not v_legacy_exists then
+                -- rename old table to _legacy
+                execute format(
+                    'alter table pgfr_record.%I rename to %I',
+                    v_table_name,
+                    v_legacy_name
+                );
+                raise notice 'migrate_to_v2: renamed pgfr_record.% → pgfr_record.%',
+                    v_table_name, v_legacy_name;
+                v_actions := v_actions || format('renamed %s → %s', v_table_name, v_legacy_name);
+                v_already_done := false;
+
+            elsif v_legacy_exists and not v_original_exists then
+                raise notice 'migrate_to_v2: pgfr_record.% already renamed to pgfr_record.% — skipping',
+                    v_table_name, v_legacy_name;
+
+            elsif v_original_exists and v_legacy_exists then
+                -- both exist — something unexpected; report it
+                raise notice 'migrate_to_v2: both pgfr_record.% and pgfr_record.% exist — manual intervention required',
+                    v_table_name, v_legacy_name;
+                v_actions := v_actions || format(
+                    'WARNING: both %s and %s exist — skipped',
+                    v_table_name, v_legacy_name
+                );
+                v_already_done := false;
+
+            else
+                -- neither original nor legacy exists — nothing to migrate for this table
+                raise notice 'migrate_to_v2: pgfr_record.% not found — skipping',
+                    v_table_name;
+            end if;
+        end;
+    end loop;
+
+    -- ----------------------------------------------------------------
+    -- Step 3: create backwards-compat views (one per renamed table).
+    -- The view replaces the old table name so existing SELECT queries
+    -- continue to work without modification.
+    -- ----------------------------------------------------------------
+    foreach v_table_name in array v_old_tables loop
+        declare
+            v_legacy_name text := v_table_name || '_legacy';
+            v_view_exists boolean;
+        begin
+            -- only create the view if the _legacy table exists
+            if not exists (
+                select 1
+                from pg_catalog.pg_class c
+                join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+                where n.nspname = 'pgfr_record'
+                  and c.relname = v_legacy_name
+                  and c.relkind = 'r'
+            ) then
+                continue;
+            end if;
+
+            -- create or replace the backwards-compat view
+            execute format(
+                'create or replace view pgfr_record.%I as select * from pgfr_record.%I',
+                v_table_name,
+                v_legacy_name
+            );
+            raise notice 'migrate_to_v2: created/updated backwards-compat view pgfr_record.%',
+                v_table_name;
+            v_actions := v_actions || format('created view %s → %s', v_table_name, v_legacy_name);
+        end;
+    end loop;
+
+    -- ----------------------------------------------------------------
+    -- Step 4: return summary
+    -- ----------------------------------------------------------------
+    if v_already_done and array_length(v_actions, 1) is null then
+        v_summary := 'migrate_to_v2: already migrated — legacy tables exist, no changes made';
+    elsif array_length(v_actions, 1) is null then
+        v_summary := 'migrate_to_v2: nothing to migrate — original tables not found';
+    else
+        v_summary := 'migrate_to_v2: ' || array_to_string(v_actions, '; ');
+    end if;
+
+    raise notice '%', v_summary;
+    return v_summary;
+end;
+$$;
+
+comment on function pgfr_record.migrate_to_v2() is
+'Phase 1 migration: renames old plain tables to _legacy suffix and creates backwards-compat views. '
+'Idempotent — safe to call multiple times. '
+'Requires v2 tables (statement_snapshots_v2, table_snapshots_v2, index_snapshots_v2) to exist first. '
+'Run AFTER installing the new _record/install.sql. '
+'Old data is preserved in _legacy tables — nothing is deleted.';

--- a/_record/migrate_phase1.sql
+++ b/_record/migrate_phase1.sql
@@ -37,7 +37,8 @@ declare
         'table_snapshots',
         'index_snapshots'
     ];
-    v_already_done boolean := true;
+    v_already_done boolean := false;
+    v_any_legacy   boolean := false;
 begin
     -- ----------------------------------------------------------------
     -- Step 1: verify v2 tables exist.
@@ -94,6 +95,9 @@ begin
 
             if v_original_exists and not v_legacy_exists then
                 -- rename old table to _legacy
+                -- lock_timeout guards against long-running queries holding AccessShareLock
+                -- and causing a cascading lock pile-up on a live system
+                set local lock_timeout = '2s';
                 execute format(
                     'alter table pgfr_record.%I rename to %I',
                     v_table_name,
@@ -107,6 +111,7 @@ begin
             elsif v_legacy_exists and not v_original_exists then
                 raise notice 'migrate_to_v2: pgfr_record.% already renamed to pgfr_record.% — skipping',
                     v_table_name, v_legacy_name;
+                v_any_legacy := true;
 
             elsif v_original_exists and v_legacy_exists then
                 -- both exist — something unexpected; report it
@@ -154,6 +159,13 @@ begin
                 v_table_name,
                 v_legacy_name
             );
+            execute format(
+                $c$comment on view pgfr_record.%I is
+                'Backwards-compatibility view: redirects reads from the old %s table '
+                'to %s_legacy after Phase 1 migration. '
+                'For new queries, use the v2 partitioned table instead.'$c$,
+                v_table_name, v_table_name, v_table_name
+            );
             raise notice 'migrate_to_v2: created/updated backwards-compat view pgfr_record.%',
                 v_table_name;
             v_actions := v_actions || format('created view %s → %s', v_table_name, v_legacy_name);
@@ -163,10 +175,10 @@ begin
     -- ----------------------------------------------------------------
     -- Step 4: return summary
     -- ----------------------------------------------------------------
-    if v_already_done and array_length(v_actions, 1) is null then
+    if v_any_legacy and array_length(v_actions, 1) is null then
         v_summary := 'migrate_to_v2: already migrated — legacy tables exist, no changes made';
-    elsif array_length(v_actions, 1) is null then
-        v_summary := 'migrate_to_v2: nothing to migrate — original tables not found';
+    elsif not v_any_legacy and array_length(v_actions, 1) is null then
+        v_summary := 'migrate_to_v2: nothing to migrate — original tables not found (fresh install?)';
     else
         v_summary := 'migrate_to_v2: ' || array_to_string(v_actions, '; ');
     end if;

--- a/_record/tests/test_migration.sql
+++ b/_record/tests/test_migration.sql
@@ -1,0 +1,166 @@
+-- =============================================================================
+-- pgfr_record pgTAP Tests — Phase 1 Migration (Issue #10)
+-- =============================================================================
+-- Tests: migrate_to_v2() function existence, idempotency, and correctness
+-- Requires: install.sql loaded; v2 stub tables created by the test setup below
+-- =============================================================================
+
+begin;
+select plan(10);
+
+-- =============================================================================
+-- Setup: create minimal v2 stub tables so migrate_to_v2() can find them.
+-- In production these are created by the new install.sql.  Here we create them
+-- as empty stubs so the migration logic can be exercised in isolation without
+-- requiring the full Phase 1 implementation to be merged.
+-- =============================================================================
+do $$
+begin
+    -- statement_snapshots_v2 stub
+    if not exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record' and c.relname = 'statement_snapshots_v2'
+    ) then
+        create table pgfr_record.statement_snapshots_v2 (
+            snapshot_id bigint,
+            queryid     bigint
+        );
+    end if;
+
+    -- table_snapshots_v2 stub
+    if not exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record' and c.relname = 'table_snapshots_v2'
+    ) then
+        create table pgfr_record.table_snapshots_v2 (
+            snapshot_id bigint,
+            relid       oid
+        );
+    end if;
+
+    -- index_snapshots_v2 stub
+    if not exists (
+        select 1 from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record' and c.relname = 'index_snapshots_v2'
+    ) then
+        create table pgfr_record.index_snapshots_v2 (
+            snapshot_id bigint,
+            indexrelid  oid
+        );
+    end if;
+end;
+$$;
+
+-- =============================================================================
+-- Test 1: migrate_to_v2() function exists
+-- =============================================================================
+select has_function(
+    'pgfr_record',
+    'migrate_to_v2',
+    'Function pgfr_record.migrate_to_v2() should exist'
+);
+
+-- =============================================================================
+-- Test 2: function has a COMMENT (documentation contract)
+-- =============================================================================
+select ok(
+    (
+        select obj_description(
+            'pgfr_record.migrate_to_v2'::regproc,
+            'pg_proc'
+        ) is not null
+    ),
+    'pgfr_record.migrate_to_v2() should have a COMMENT'
+);
+
+-- =============================================================================
+-- Test 3: migrate_to_v2() runs without error (first call)
+-- =============================================================================
+select lives_ok(
+    $$select pgfr_record.migrate_to_v2()$$,
+    'migrate_to_v2() should execute without error on first call'
+);
+
+-- =============================================================================
+-- Test 4: after migration, statement_snapshots_legacy table exists
+-- =============================================================================
+select has_table(
+    'pgfr_record',
+    'statement_snapshots_legacy',
+    'Table pgfr_record.statement_snapshots_legacy should exist after migration'
+);
+
+-- =============================================================================
+-- Test 5: after migration, original statement_snapshots table is GONE (renamed)
+-- The name now belongs to a view, not a plain table.
+-- =============================================================================
+select ok(
+    not exists (
+        select 1
+        from pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n on n.oid = c.relnamespace
+        where n.nspname = 'pgfr_record'
+          and c.relname  = 'statement_snapshots'
+          and c.relkind  = 'r'  -- plain heap table
+    ),
+    'pgfr_record.statement_snapshots should no longer be a plain table after migration'
+);
+
+-- =============================================================================
+-- Test 6: after migration, statement_snapshots VIEW exists
+-- =============================================================================
+select has_view(
+    'pgfr_record',
+    'statement_snapshots',
+    'View pgfr_record.statement_snapshots should exist after migration (backwards compat)'
+);
+
+-- =============================================================================
+-- Test 7: the view reads from _legacy (smoke-test: query returns without error)
+-- =============================================================================
+select lives_ok(
+    $$select count(*) from pgfr_record.statement_snapshots$$,
+    'SELECT from pgfr_record.statement_snapshots view should succeed (backwards compat)'
+);
+
+-- =============================================================================
+-- Test 8: idempotency — second call runs without error
+-- =============================================================================
+select lives_ok(
+    $$select pgfr_record.migrate_to_v2()$$,
+    'migrate_to_v2() should be idempotent (second call must not raise an error)'
+);
+
+-- =============================================================================
+-- Test 9: idempotency — statement_snapshots_legacy still exists after second call
+-- =============================================================================
+select has_table(
+    'pgfr_record',
+    'statement_snapshots_legacy',
+    'statement_snapshots_legacy should still exist after second migrate_to_v2() call'
+);
+
+-- =============================================================================
+-- Test 10: migrate_to_v2() raises ERROR when v2 tables are missing
+-- =============================================================================
+do $$
+begin
+    -- temporarily drop the v2 stubs to simulate "install.sql not run" scenario
+    drop table if exists pgfr_record.statement_snapshots_v2 cascade;
+    drop table if exists pgfr_record.table_snapshots_v2 cascade;
+    drop table if exists pgfr_record.index_snapshots_v2 cascade;
+end;
+$$;
+
+select throws_ok(
+    $$select pgfr_record.migrate_to_v2()$$,
+    'P0001',
+    NULL,
+    'migrate_to_v2() should raise an error when v2 tables do not exist'
+);
+
+select * from finish();
+rollback;

--- a/blueprints/SPEC.md
+++ b/blueprints/SPEC.md
@@ -1248,29 +1248,41 @@ filterable anomaly; an autovacuum death spiral from a cascade is catastrophic.
 Enforce integrity at the collection layer and rely on aligned `sample_ts` partition
 boundaries for clean retention.
 
-**Q2: Migration for existing installations.**
-For Phase 1 (`statement_snapshots`), implement as a dual-write: the old table
-continues receiving full inserts while the new partitioned table receives sparse
-inserts in parallel. This costs 2× storage temporarily but eliminates rollback
-risk. Define new partitioned tables with `BIGINT` for `snapshot_id` from day one
-(see Q5) — the collector safely inserts the current `INT` sequence value into a
-`BIGINT` column. When the parent `snapshots` table is migrated to `BIGSERIAL` in
-Phase 2, child tables are already correctly typed, avoiding a second migration.
+**Q2: Migration for existing installations. ✅ RESOLVED — implemented in `_record/migrate_phase1.sql` (Issue #10)**
+
+The migration approach: instead of dual-write, rename old plain tables to `_legacy`
+suffix and create backwards-compatible views so existing SELECT queries continue to
+work unmodified. Old data is preserved — nothing is deleted.
+
+**Migration function:** `pgfr_record.migrate_to_v2()` — run once after installing
+the new `_record/install.sql`. Idempotent: safe to call multiple times.
+
+**What it does (in order):**
+1. Checks that v2 tables exist (`statement_snapshots_v2`, `table_snapshots_v2`,
+   `index_snapshots_v2`) — raises ERROR with clear instructions if not found
+2. Renames old plain tables to `_legacy` suffix (skips if already renamed):
+   - `statement_snapshots` → `statement_snapshots_legacy`
+   - `table_snapshots` → `table_snapshots_legacy`
+   - `index_snapshots` → `index_snapshots_legacy`
+3. Creates backwards-compat views: `statement_snapshots` (and equivalents) now
+   point to the `_legacy` table — existing monitoring dashboards and tools keep working
+4. Returns a text summary of all actions taken
 
 **Cutover checklist (ordered — do not skip steps):**
-1. Verify new schema has ≥ 1 full retention cycle (30 days) of data
-2. Validate reader output matches between old and new schema for several time windows
-3. In a single maintenance window: switch reader config flag to new schema AND
-   disable old-schema writer in the collection function (do not split these across
-   separate windows — dual-read window must be minimized)
-4. Verify readers return correct results from new schema only
-5. Wait one additional retention cycle for old data to expire naturally,
-   OR drop old table immediately if storage is urgent
-6. Drop old table
+1. Install the new `_record/install.sql` (creates v2 tables)
+2. Run `SELECT pgfr_record.migrate_to_v2();` — verifies v2 tables, renames old tables
+3. Verify backwards-compat views work: `SELECT count(*) FROM pgfr_record.statement_snapshots;`
+4. Verify new v2 tables are receiving data from the collector
+5. After ≥ 1 full retention cycle of v2 data, drop `_legacy` tables if storage is urgent
+   (or leave them as a historical archive — they contain no live data)
 
-If the config flag is switched while both writers are active, readers may see
-duplicate data. If the old table is dropped before the flag is switched, readers
-break. Steps 3 and 4 must happen in the same maintenance window.
+**Rollback:** rename `_legacy` tables back to their original names and drop the views.
+Old data is fully preserved.
+
+**Dual-write strategy (from earlier SPEC version) is superseded** by this rename
+approach. The rename is safer: no risk of duplicate data, no config flag to toggle,
+no 2× storage cost. The only tradeoff is a brief maintenance window to run the
+rename — which is a single metadata operation with no data movement.
 
 **Q3: Partition pruning with dynamic bounds.**
 `now()` is stable within a transaction and `epoch()` is IMMUTABLE — the planner


### PR DESCRIPTION
Implements #10. Adds migrate_phase1.sql with migrate_to_v2() function, backwards-compat views, idempotent design. Closes #10