### PR TITLE
fix(pgfr_record): add DEFAULT partition to all range-partitioned tables (C3)

### DIFF
--- a/pgfr_record/sql/07_sparse_collectors.sql
+++ b/pgfr_record/sql/07_sparse_collectors.sql
@@ -34,6 +34,9 @@ create table if not exists pgfr_record.statement_snapshots_v2 (
     pgss_dealloc_warning    boolean         not null default false  -- cluster-level PGSS eviction event
 ) partition by range (sample_ts);
 
+create table if not exists pgfr_record.statement_snapshots_v2_default
+    partition of pgfr_record.statement_snapshots_v2 default;
+
 comment on table pgfr_record.statement_snapshots_v2 is
 'Sparse PGSS history partitioned by int4 sample_ts (seconds since pgfr_record.epoch()). '
 'Dual-write: old statement_snapshots retained. Missing row = no change since last stored row. '
@@ -367,6 +370,9 @@ create table if not exists pgfr_record.table_snapshots_v2 (
     indexes_size_bytes  bigint
 ) partition by range (sample_ts);
 
+create table if not exists pgfr_record.table_snapshots_v2_default
+    partition of pgfr_record.table_snapshots_v2 default;
+
 comment on table pgfr_record.table_snapshots_v2 is
 'Sparse table-level stats history partitioned by int4 sample_ts (seconds since pgfr_record.epoch()). '
 'Missing row = no change since last stored row. '
@@ -639,6 +645,9 @@ create table if not exists pgfr_record.index_snapshots_v2 (
     idx_tup_fetch       bigint,
     index_size_bytes    bigint
 ) partition by range (sample_ts);
+
+create table if not exists pgfr_record.index_snapshots_v2_default
+    partition of pgfr_record.index_snapshots_v2 default;
 
 comment on table pgfr_record.index_snapshots_v2 is
 'Sparse index-level stats history partitioned by int4 sample_ts (seconds since pgfr_record.epoch()). '

--- a/pgfr_record/sql/09_phase3_snapshots_v2.sql
+++ b/pgfr_record/sql/09_phase3_snapshots_v2.sql
@@ -84,6 +84,9 @@ create table if not exists pgfr_record.snapshots_v2 (
     large_object_count  bigint
 ) partition by range (sample_ts);
 
+create table if not exists pgfr_record.snapshots_v2_default
+    partition of pgfr_record.snapshots_v2 default;
+
 comment on table pgfr_record.snapshots_v2 is
 'Cluster-level snapshot metrics, daily RANGE-partitioned by int4 sample_ts. '
 'No FK constraints: child tables use snapshot_id as logical (non-enforced) reference. '
@@ -112,6 +115,9 @@ create table if not exists pgfr_record.replication_snapshots_v2 (
     reply_time          timestamptz
 ) partition by range (sample_ts);
 
+create table if not exists pgfr_record.replication_snapshots_v2_default
+    partition of pgfr_record.replication_snapshots_v2 default;
+
 comment on table pgfr_record.replication_snapshots_v2 is
 'Per-replica replication state, daily RANGE-partitioned by int4 sample_ts. '
 'snapshot_id is a logical (non-FK) reference to snapshots_v2. '
@@ -134,6 +140,9 @@ create table if not exists pgfr_record.vacuum_progress_snapshots_v2 (
     max_dead_tuples     bigint,
     num_dead_tuples     bigint
 ) partition by range (sample_ts);
+
+create table if not exists pgfr_record.vacuum_progress_snapshots_v2_default
+    partition of pgfr_record.vacuum_progress_snapshots_v2 default;
 
 comment on table pgfr_record.vacuum_progress_snapshots_v2 is
 'In-progress VACUUM state per snapshot tick, daily RANGE-partitioned by int4 sample_ts. '
@@ -467,6 +476,9 @@ create table if not exists pgfr_record.activity_samples_archive_v2 (
     query_preview       text
 ) partition by range (sample_ts);
 
+create table if not exists pgfr_record.activity_samples_archive_v2_default
+    partition of pgfr_record.activity_samples_archive_v2 default;
+
 comment on table pgfr_record.activity_samples_archive_v2 is
 'Activity samples archive, daily RANGE-partitioned by int4 sample_ts. '
 'No BIGSERIAL PK, no FK. Retention via truncate_old_partitions() / drop_ancient_partitions(). '
@@ -491,6 +503,9 @@ create table if not exists pgfr_record.lock_samples_archive_v2 (
     locked_relation_oid     oid
 ) partition by range (sample_ts);
 
+create table if not exists pgfr_record.lock_samples_archive_v2_default
+    partition of pgfr_record.lock_samples_archive_v2 default;
+
 comment on table pgfr_record.lock_samples_archive_v2 is
 'Lock samples archive, daily RANGE-partitioned by int4 sample_ts. '
 'No BIGSERIAL PK, no FK. Retention via truncate_old_partitions() / drop_ancient_partitions().';
@@ -507,6 +522,9 @@ create table if not exists pgfr_record.wait_samples_archive_v2 (
     state               text,
     count               integer
 ) partition by range (sample_ts);
+
+create table if not exists pgfr_record.wait_samples_archive_v2_default
+    partition of pgfr_record.wait_samples_archive_v2 default;
 
 comment on table pgfr_record.wait_samples_archive_v2 is
 'Wait event samples archive, daily RANGE-partitioned by int4 sample_ts. '


### PR DESCRIPTION
Fixes **C3** from #29.

## Problem

Nine `partition by range (sample_ts)` tables in `pgfr_record/` had no DEFAULT partition:

- `pgfr_record/sql/07_sparse_collectors.sql:35, 368, 641` — `statement_snapshots_v2`, `table_snapshots_v2`, `index_snapshots_v2`
- `pgfr_record/sql/09_phase3_snapshots_v2.sql:85, 113, 136, 468, 492, 509` — `snapshots_v2`, `replication_snapshots_v2`, `vacuum_progress_snapshots_v2`, and the three `*_archive_v2` tables

Any row with a `sample_ts` that doesn't fall into an existing daily partition fails to INSERT with `no partition of relation matches the partition key`. The window for this is small but real:

1. `snapshot()` wraps `_ensure_partition()` in `EXCEPTION WHEN OTHERS THEN RAISE WARNING` (see `pgfr_record/sql/04b_functions_snapshot.sql:755-769`). If the partition-create fails for any reason, the subsequent INSERT has no landing spot.
2. First tick of the day if `_ensure_partition()` races with the clock.
3. Clock skew on pg_cron workers.

A DEFAULT partition turns this failure into a graceful "land it here for now" behavior.

## Change

Nine new lines, one per parent:

```sql
create table if not exists pgfr_record.<table>_default
    partition of pgfr_record.<table> default;
```

Idempotent, same pattern as the existing `create table if not exists` for the parents.

## Interaction with GC

`_partition_inventory()` in `pgfr_record/sql/06_partition_infra.sql:321` filters out rows with unparseable bounds (`and parsed.bounds is not null`). DEFAULT partitions return `"DEFAULT"` from `pg_get_expr()`, not the `FOR VALUES FROM ... TO ...` pattern the regex matches, so they're naturally excluded from `truncate_old_partitions()` and `drop_ancient_partitions()`. That's the correct behavior — DEFAULT is meant to persist and catch misrouted rows.

## Existing installs

Safe. `CREATE TABLE ... PARTITION OF <parent> DEFAULT` acquires a brief `ACCESS EXCLUSIVE` on the parent partitioned table but doesn't scan or rewrite data. `IF NOT EXISTS` makes re-running `install.sql` a no-op.

## CI status

PG 15/16/17 all green on this PR. (The PG 18 matrix entry landed via #32 after this PR was opened; running against current `main` will exercise it too.) Shell/Markdown Lint failures are pre-existing on `main`, not caused by this diff.

## Follow-ups (out of scope here)

- **Monitor DEFAULT partition growth.** If rows are landing in DEFAULT regularly, something upstream is broken. Suggest extending `partition_gc_health` view to surface `pg_relation_size(<table>_default)` per parent so operators can alert on it.
- **Test.** A pgTAP assertion that each parent has exactly one child matching `%_default` would lock in the contract — easy follow-up.

---

<sub>Part of the review in #29. Sibling of #31 (dbdev packaging / C1, merged) and #32 (PG 18 / C2, merged).</sub>